### PR TITLE
Expanded range of PID and windup gains for certain applications. 

### DIFF
--- a/cfg/Parameters.cfg
+++ b/cfg/Parameters.cfg
@@ -40,11 +40,11 @@ PACKAGE='control_toolbox'
 
 def generate(gen):
 	#        Name            Type    Level  Description      Default  Min  Max
-	gen.add( "p_gain" ,      double_t, 1,"Proportional gain.", 10.0 , 0 , 1000)
-	gen.add( "i_gain" ,      double_t, 1,"Integral gain.",     10.0 , 0 , 100)
-	gen.add( "d_gain" ,      double_t, 1,"Derivative gain.",   10.0 , 0 , 100)
-	gen.add( "i_clamp_min" , double_t, 1,"Min bounds for the integral windup",   10.0 , 0 , 100)
-	gen.add( "i_clamp_max" , double_t, 1,"Max bounds for the integral windup",   10.0 , 0 , 100)
+	gen.add( "p_gain" ,      double_t, 1,"Proportional gain.", 10.0 , 0 , 100000)
+	gen.add( "i_gain" ,      double_t, 1,"Integral gain.",     0.1 , 0 , 1000)
+	gen.add( "d_gain" ,      double_t, 1,"Derivative gain.",   1.0 , 0 , 1000)
+	gen.add( "i_clamp_min" , double_t, 1,"Min bounds for the integral windup",   10.0 , 0 , 1000)
+	gen.add( "i_clamp_max" , double_t, 1,"Max bounds for the integral windup",   10.0 , 0 , 1000)
 	                 # PkgName  #NodeName         #Prefix for generated .h include file, e.g. ParametersConfig.py
 	exit(gen.generate(PACKAGE, "control_toolbox", "Parameters"))
 


### PR DESCRIPTION
Also lowered default integral and derivative gains to more reasonable values.

I created this dynamic reconfigure file recently but I think I set the max values too low. This fix is for the Baxter in simulation.
