### PR TITLE
Fix abs/fabs problem with Clang and libc++

### DIFF
--- a/src/limited_proxy.cpp
+++ b/src/limited_proxy.cpp
@@ -35,6 +35,7 @@
 #include <control_toolbox/limited_proxy.h>
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 
 namespace control_toolbox {
 


### PR DESCRIPTION
Prevents the error: use of undeclared identifier 'abs'; did you mean 'fabs'?
with Clang 5 on Mac OS X Mavericks
