### PR TITLE
Fix for i_clamp_min to be negative in dynamic reconfigure

### DIFF
--- a/cfg/Parameters.cfg
+++ b/cfg/Parameters.cfg
@@ -43,7 +43,7 @@ def generate(gen):
 	gen.add( "p_gain" ,      double_t, 1,"Proportional gain.", 10.0 , 0 , 100000)
 	gen.add( "i_gain" ,      double_t, 1,"Integral gain.",     0.1 , 0 , 1000)
 	gen.add( "d_gain" ,      double_t, 1,"Derivative gain.",   1.0 , 0 , 1000)
-	gen.add( "i_clamp_min" , double_t, 1,"Min bounds for the integral windup",   10.0 , 0 , 1000)
+	gen.add( "i_clamp_min" , double_t, 1,"Min bounds for the integral windup",   10.0 , -1000 , 0)
 	gen.add( "i_clamp_max" , double_t, 1,"Max bounds for the integral windup",   10.0 , 0 , 1000)
 	                 # PkgName  #NodeName         #Prefix for generated .h include file, e.g. ParametersConfig.py
 	exit(gen.generate(PACKAGE, "control_toolbox", "Parameters"))


### PR DESCRIPTION
Fix to bug in https://github.com/ros-controls/control_toolbox/issues/10
