### PR TITLE
Unnecessary dependency on tf causing sensor_msgs bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ else()
   find_package(catkin REQUIRED COMPONENTS
     rosconsole
     message_generation
-    tf
     roscpp
     angles
     dynamic_reconfigure
@@ -69,7 +68,6 @@ else()
     DEPENDS tinyxml
     CATKIN_DEPENDS 
       rosconsole 
-      tf 
       roscpp 
       angles 
       dynamic_reconfigure

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>rosconsole</build_depend> 
-  <build_depend>tf</build_depend> 
   <build_depend>roscpp</build_depend> 
   <build_depend>angles</build_depend> 
   <build_depend>message_generation</build_depend> 
@@ -26,7 +25,6 @@
   <build_depend>realtime_tools</build_depend>
 
   <run_depend>rosconsole</run_depend> 
-  <run_depend>tf</run_depend> 
   <run_depend>roscpp</run_depend> 
   <run_depend>angles</run_depend> 
   <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
After investigating all of `control_toolbox`'s dependencies, I found this one to be the one causing the problem in https://github.com/ros-controls/control_toolbox/issues/13

@tfoote any idea why this might be?
