### PR TITLE
Cleaned up CMake and removed unnecessary dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,22 +32,16 @@ else()
 
   # Load catkin and all dependencies required for this package
   find_package(catkin REQUIRED COMPONENTS
-    rosconsole
+    cmake_modules
     message_generation
-    tf
     roscpp
-    angles
     dynamic_reconfigure
     realtime_tools
+    std_msgs
     )
 
   find_package(Boost REQUIRED COMPONENTS system thread)
-
-  include_directories(
-    include
-    ${catkin_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIR}
-    )
+  find_package(TinyXML REQUIRED)
 
   # Dynamics reconfigure
   generate_dynamic_reconfigure_options(
@@ -62,20 +56,26 @@ else()
 
   generate_messages(
     DEPENDENCIES std_msgs
-    )
+  )
 
   # Declare catkin package
   catkin_package(
-    DEPENDS tinyxml
+    DEPENDS TinyXML
     CATKIN_DEPENDS 
-      rosconsole 
-      tf 
       roscpp 
-      angles 
       dynamic_reconfigure
       realtime_tools
+      message_runtime
+      std_msgs
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
+    )
+
+  include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIR}
+    ${TinyXML_INCLUDE_DIRS}
     )
 
   add_library(${PROJECT_NAME}
@@ -88,7 +88,7 @@ else()
     )
   add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg) # wait for dynamic reconfigure
 
-  target_link_libraries(${PROJECT_NAME} tinyxml ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
   add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp) # wait for msgs
 

--- a/include/control_toolbox/dither.h
+++ b/include/control_toolbox/dither.h
@@ -34,8 +34,8 @@
 
 /**< \author Kevin Watts */
 
-#ifndef CTRL_TOOLBOX_DITHER_H
-#define CTRL_TOOLBOX_DITHER_H
+#ifndef CONTROL_TOOLBOX__DITHER_H
+#define CONTROL_TOOLBOX__DITHER_H
 
 #include <cstdlib>
 #include <ctime>

--- a/include/control_toolbox/filters.h
+++ b/include/control_toolbox/filters.h
@@ -32,8 +32,8 @@
 *  POSSIBILITY OF SUCH DAMAGE.
 *********************************************************************/
 
-#ifndef FILTERS_H
-#define FILTERS_H
+#ifndef CONTROL_TOOLBOX__FILTERS_H
+#define CONTROL_TOOLBOX__FILTERS_H
 
 #include <algorithm>
 

--- a/include/control_toolbox/limited_proxy.h
+++ b/include/control_toolbox/limited_proxy.h
@@ -31,8 +31,8 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-#ifndef CONTROL_TOOLBOX_LIMITED_PROXY_H
-#define CONTROL_TOOLBOX_LIMITED_PROXY_H
+#ifndef CONTROL_TOOLBOX__LIMITED_PROXY_H
+#define CONTROL_TOOLBOX__LIMITED_PROXY_H
 
 namespace control_toolbox {
 

--- a/include/control_toolbox/pid.h
+++ b/include/control_toolbox/pid.h
@@ -31,8 +31,8 @@
  *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
-#ifndef CONTROL_TOOLBOX_PID_H
-#define CONTROL_TOOLBOX_PID_H
+#ifndef CONTROL_TOOLBOX__PID_H
+#define CONTROL_TOOLBOX__PID_H
 
 
 #include <string>

--- a/include/control_toolbox/pid_gains_setter.h
+++ b/include/control_toolbox/pid_gains_setter.h
@@ -31,8 +31,8 @@
 //
 // Author: Stuart Glaser
 
-#ifndef PID_GAINS_SETTER_H
-#define PID_GAINS_SETTER_H
+#ifndef CONTROL_TOOLBOX__PID_GAINS_SETTER_H
+#define CONTROL_TOOLBOX__PID_GAINS_SETTER_H
 
 #include <vector>
 #include <string>

--- a/include/control_toolbox/sine_sweep.h
+++ b/include/control_toolbox/sine_sweep.h
@@ -33,8 +33,8 @@
  *********************************************************************/
 
 
-#ifndef CTRL_TOOLBOX_SINESWEEP_H
-#define CTRL_TOOLBOX_SINESWEEP_H
+#ifndef CONTROL_TOOLBOX__SINESWEEP_H
+#define CONTROL_TOOLBOX__SINESWEEP_H
 
 #include <ros/ros.h>
 

--- a/include/control_toolbox/sinusoid.h
+++ b/include/control_toolbox/sinusoid.h
@@ -34,8 +34,8 @@
 
 /** \author Mrinal Kalakrishnan */
 
-#ifndef SINUSOID_H_
-#define SINUSOID_H_
+#ifndef CONTROL_TOOLBOX__SINUSOID_H_
+#define CONTROL_TOOLBOX__SINUSOID_H_
 
 #include <iostream>
 #include <tinyxml.h>

--- a/package.xml
+++ b/package.xml
@@ -16,24 +16,22 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>rosconsole</build_depend> 
-  <build_depend>tf</build_depend> 
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>std_msgs</build_depend> 
   <build_depend>roscpp</build_depend> 
-  <build_depend>angles</build_depend> 
   <build_depend>message_generation</build_depend> 
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>tinyxml</build_depend>
   <build_depend>realtime_tools</build_depend>
 
-  <run_depend>rosconsole</run_depend> 
-  <run_depend>tf</run_depend> 
+  <run_depend>cmake_modules</run_depend>
+  <run_depend>std_msgs</run_depend> 
   <run_depend>roscpp</run_depend> 
-  <run_depend>angles</run_depend> 
   <run_depend>message_runtime</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>tinyxml</run_depend>
   <run_depend>realtime_tools</run_depend>
-  
+
   <export>
     <cpp lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib -lcontrol_toolbox" cflags="-I${prefix}/include -I${prefix}/include/control_toolbox/eigen2"/>
   </export>


### PR DESCRIPTION
While attempting to fix https://github.com/ros-controls/control_toolbox/issues/13 I found lots of stuff that needed cleaning up thanks to catkin_lint as well as my experience. This is targeted for indigo, so as to not cause any dependency changes in a stable release. However, it's only been tested in hydro, I just created the `indigo-devel` branch just now so I can merge this in.
