### PR TITLE
pid: Adding quiet flag to suppress error message

### DIFF
--- a/include/control_toolbox/pid.h
+++ b/include/control_toolbox/pid.h
@@ -189,16 +189,18 @@ public:
    *        Initializes dynamic reconfigure for PID gains
    *
    * \param prefix The namespace prefix.
+   * \param quiet If true, no error messages will be emitted on failure.
    */
-  bool initParam(const std::string& prefix);
+  bool initParam(const std::string& prefix, const bool quiet=false);
 
   /*!
    * \brief Initialize PID with the parameters in a NodeHandle namespace
    *        Initializes dynamic reconfigure for PID gains
    *
    * \param n The NodeHandle which should be used to query parameters.
+   * \param quiet If true, no error messages will be emitted on failure.
    */
-  bool init(const ros::NodeHandle &n);
+  bool init(const ros::NodeHandle &n, const bool quiet=false);
 
   /*!
    * \brief Initialize PID with the parameters in an XML element

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -84,13 +84,13 @@ void Pid::initPid(double p, double i, double d, double i_max, double i_min)
   reset();
 }
 
-bool Pid::initParam(const std::string& prefix)
+bool Pid::initParam(const std::string& prefix, const bool quiet)
 {
   ros::NodeHandle nh(prefix);
-  return init(nh);
+  return init(nh, quiet);
 }
 
-bool Pid::init(const ros::NodeHandle &node)
+bool Pid::init(const ros::NodeHandle &node, const bool quiet)
 {
   ros::NodeHandle nh(node);
 
@@ -99,7 +99,9 @@ bool Pid::init(const ros::NodeHandle &node)
   // Load PID gains from parameter server
   if (!nh.getParam("p", gains.p_gain_)) 
   {
-    ROS_ERROR("No p gain specified for pid.  Namespace: %s", nh.getNamespace().c_str());
+    if (!quiet) {
+      ROS_ERROR("No p gain specified for pid.  Namespace: %s", nh.getNamespace().c_str());
+    }
     return false;
   }
   // Only the P gain is required, the I and D gains are optional and default to 0:


### PR DESCRIPTION
This PR https://github.com/ros-controls/control_toolbox/pull/21 needs to be merged into the `hydro-devel` branch in order to allow the change in [gazebo_ros_pkgs](https://github.com/ros-simulation/gazebo_ros_pkgs/commit/4776545954d55749f070eaf95b7d762d5eab0187) to compile. Or perhaps we should not have added that to the hydro-devel branch @jbohren ?

Does this change to PID break abi-compatibility? I know its an optional parameter so in theory no, but this kind of thing perhaps shouldn't be changed in a stable release?

This PR was required for me to build ROS from source.
