### PR TITLE
Restore hydro for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install: # Use this to install any prerequisites or dependencies necessary to ru
   - cd ~/ros/ws_ros_controls/src
   - wstool init .
   # Download non-debian stuff
-  - wstool merge https://raw.github.com/ros-controls/ros_control/indigo-devel/ros_control.rosinstall
+  - wstool merge https://raw.github.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
   - wstool update
   # Delete the ros_control.rosinstall version of this repo and use the one of the branch we are testing
   - rm -rf $REPOSITORY_NAME


### PR DESCRIPTION
So until further notice Travis uses 12.04, which complicates validating the indigo branch. In the meantime, we can try to build `indigo-devel` on top of hydro+12.04. It's possible that rosdeps will not be successfully resolved for all repos (at least ros_control should fail). If this attempt fails, I'll rollback changes to test hydro, and look for more definitive solutions to using Travis with 14.04.
