### PR TITLE
Improvement on the integral contribution implementation

### DIFF
--- a/include/control_toolbox/pid.h
+++ b/include/control_toolbox/pid.h
@@ -370,8 +370,8 @@ private:
 
   double p_error_last_; /**< _Save position state for derivative state calculation. */
   double p_error_; /**< Position error. */
-  double d_error_; /**< Derivative error. */
-  double i_term_;  /**< Integral term. */
+  double i_error_; /**< Integral of position error. */
+  double d_error_; /**< Derivative of position error. */
   double cmd_;     /**< Command to send. */
 
   // Dynamics reconfigure

--- a/test/pid_tests.cpp
+++ b/test/pid_tests.cpp
@@ -32,27 +32,23 @@ TEST(ParameterTest, zeroITermBadIBoundsTest)
 
 TEST(ParameterTest, integrationWindupTest)
 {
-  RecordProperty("description","This test succeeds if the integral error is prevented from winding up when the integral gain is non-zero.");
+  RecordProperty("description","This test succeeds if the integral contribution is prevented from winding up when the integral gain is non-zero.");
 
-  Pid pid(0.0, 1.0, 0.0, 1.0, -1.0);
+  Pid pid(0.0, 2.0, 0.0, 1.0, -1.0);
 
   double cmd = 0.0;
   double pe,ie,de;
 
   cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-  pid.getCurrentPIDErrors(&pe,&ie,&de);
-  EXPECT_EQ(-1.0, ie);
   EXPECT_EQ(-1.0, cmd);
 
   cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-  pid.getCurrentPIDErrors(&pe,&ie,&de);
-  EXPECT_EQ(-1.0, ie);
   EXPECT_EQ(-1.0, cmd);
 }
 
 TEST(ParameterTest, integrationWindupZeroGainTest)
 {
-  RecordProperty("description","This test succeeds if the integral error is prevented from winding up when the integral gain is zero. If the integral error is allowed to wind up while it is disabled, it can cause sudden jumps to the minimum or maximum bound in control command when re-enabled.");
+  RecordProperty("description","This test succeeds if the integral contribution is prevented from winding up when the integral gain is zero. If the integral contribution is allowed to wind up while it is disabled, it can cause sudden jumps to the minimum or maximum bound in control command when re-enabled.");
 
   double i_gain = 0.0;
   double i_min = -1.0;
@@ -64,14 +60,13 @@ TEST(ParameterTest, integrationWindupZeroGainTest)
 
   cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
   pid.getCurrentPIDErrors(&pe,&ie,&de);
-  EXPECT_LE(i_min, ie);
-  EXPECT_LE(ie, i_max);
+  EXPECT_LE(i_min, cmd);
+  EXPECT_LE(cmd, i_max);
   EXPECT_EQ(0.0, cmd);
 
   cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-  pid.getCurrentPIDErrors(&pe,&ie,&de);
-  EXPECT_LE(i_min, ie);
-  EXPECT_LE(ie, i_max);
+  EXPECT_LE(i_min, cmd);
+  EXPECT_LE(cmd, i_max);
   EXPECT_EQ(0.0, cmd);
 }
 


### PR DESCRIPTION
The integral of the error is computed in a class member, and the integral contribution is computed as of it, instead of doing all together. Now, setting the integral gain to zero dynamically cancel the integral contribution.

Additional update:
Function `getCurrentPIDErrors(...)` now returns the integral of the position error, and not the contribution. Because of this, also the tests were modified. Tests `integrationWindupZeroGainTest` (actually, this one makes no sense now, since the error is directly given instead of obtaining by diving the term by the gain) and `integrationWindupTest` check the windup constraint on the computed command.

I don't know how this affects the dependant packages, but I believe the change is worthy.

Resolve #32.