### PR TITLE
Update computeCommand call to match documented/expected behaviour

### DIFF
--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -369,7 +369,7 @@ double Pid::computeCommand(double error, double error_dot, ros::Duration dt)
   d_term = gains.d_gain_ * d_error_;
 
   // Compute the command
-  cmd_ = - p_term - i_term - d_term;
+  cmd_ = p_term + i_term + d_term;
 
   return cmd_;
 }


### PR DESCRIPTION
computeCommand is documented to use 'error = target - state' rather than the old 'pError = pState-pTarget' of updatePid. One of the computeCommand implementations behaves correctly (https://github.com/ros-controls/control_toolbox/blob/indigo-devel/src/pid.cpp#L372), but this one does not (https://github.com/ros-controls/control_toolbox/blob/indigo-devel/src/pid.cpp#L372).

Next pull will be to chain the calls and prevent this kind of divergence.