### PR TITLE
Response to #40

### DIFF
--- a/test/pid_tests.cpp
+++ b/test/pid_tests.cpp
@@ -9,17 +9,16 @@
 
 using namespace control_toolbox;
 
-TEST(ParameterTest, zeroITermBadIBoundsTest)
+TEST(ParameterTest, ITermBadIBoundsTest)
 {
-  RecordProperty("description","This test checks robustness against divide-by-zero errors when given integral term bounds which do not include 0.0.");
+  RecordProperty("description","This test checks that the integral contribution is robust to bad i_bounds specification (i.e. i_min > i_max).");
 
-  Pid pid(1.0, 0.0, 0.0, -1.0, 0.0);
-
+  // Check that the output is not a non-sense if i-bounds are bad, i.e. i_min > i_max
+  Pid pid(1.0, 1.0, 1.0, -1.0, 1.0);
   double cmd = 0.0;
   double pe,ie,de;
 
   cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-
   pid.getCurrentPIDErrors(&pe,&ie,&de);
   EXPECT_FALSE(boost::math::isinf(ie));
   EXPECT_FALSE(boost::math::isnan(cmd));
@@ -34,16 +33,18 @@ TEST(ParameterTest, integrationWindupTest)
 {
   RecordProperty("description","This test succeeds if the integral contribution is prevented from winding up when the integral gain is non-zero.");
 
-  Pid pid(0.0, 2.0, 0.0, 1.0, -1.0);
+  Pid pid(0.0, 1.0, 0.0, 1.0, -1.0);
 
   double cmd = 0.0;
   double pe,ie,de;
 
-  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
+  // Test lower limit
+  cmd = pid.computeCommand(-10.03, ros::Duration(1.0));
   EXPECT_EQ(-1.0, cmd);
 
-  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-  EXPECT_EQ(-1.0, cmd);
+  // Test upper limit
+  cmd = pid.computeCommand(30.0, ros::Duration(1.0));
+  EXPECT_EQ(1.0, cmd);
 }
 
 TEST(ParameterTest, integrationWindupZeroGainTest)
@@ -133,11 +134,11 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(i_min, i_min_return);
 
   // Test that errors are zero
-  double pe, ie, de;
-  pid2.getCurrentPIDErrors(&pe, &ie, &de);
-  EXPECT_EQ(0.0, pe);
-  EXPECT_EQ(0.0, ie);
-  EXPECT_EQ(0.0, de);
+  double pe2, ie2, de2;
+  pid2.getCurrentPIDErrors(&pe2, &ie2, &de2);
+  EXPECT_EQ(0.0, pe2);
+  EXPECT_EQ(0.0, ie2);
+  EXPECT_EQ(0.0, de2);
     
   // Test assignment constructor -------------------------------------------------
   Pid pid3;
@@ -152,11 +153,143 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(i_min, i_min_return);
 
   // Test that errors are zero
-  double pe2, ie2, de2;
-  pid3.getCurrentPIDErrors(&pe2, &ie2, &de2);
-  EXPECT_EQ(0.0, pe2);
-  EXPECT_EQ(0.0, ie2);
-  EXPECT_EQ(0.0, de2);
+  double pe3, ie3, de3;
+  pid3.getCurrentPIDErrors(&pe3, &ie3, &de3);
+  EXPECT_EQ(0.0, pe3);
+  EXPECT_EQ(0.0, ie3);
+  EXPECT_EQ(0.0, de3);
+
+  // Test the reset() function, it should clear errors and command
+  pid1.reset();
+
+  double pe1, ie1, de1;
+  pid1.getCurrentPIDErrors(&pe1, &ie1, &de1);
+  EXPECT_EQ(0.0, pe1);
+  EXPECT_EQ(0.0, ie1);
+  EXPECT_EQ(0.0, de1);
+
+  double cmd1 = pid1.getCurrentCmd();
+  EXPECT_EQ(0.0, cmd1);
+}
+
+TEST(CommandTest, proportionalOnlyTest)
+{
+  RecordProperty("description","This test checks that a command is computed correctly using the proportional contribution only.");
+
+  // Set only proportional gain
+  Pid pid(1.0, 0.0, 0.0, 0.0, 0.0);
+  double cmd = 0.0;
+
+  // If initial error = 0, p-gain = 1, dt = 1
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect command = error
+  EXPECT_EQ(-0.5, cmd);
+
+  // If call again
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect the same as before
+  EXPECT_EQ(-0.5, cmd);
+
+  // If call again doubling the error
+  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
+  // Then expect the command doubl-ed
+  EXPECT_EQ(-1.0, cmd);
+
+  // If call with positive error
+  cmd = pid.computeCommand(0.5, ros::Duration(1.0));
+  // Then expect always command = error
+  EXPECT_EQ(0.5, cmd);
+}
+
+TEST(CommandTest, integralOnlyTest)
+{
+  RecordProperty("description","This test checks that a command is computed correctly using the integral contribution only (ATTENTION: this test depends on the integration scheme).");
+
+  // Set only integral gains with enough limits to test behavior
+  Pid pid(0.0, 1.0, 0.0, 5.0, -5.0);
+  double cmd = 0.0;
+
+  // If initial error = 0, i-gain = 1, dt = 1
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect command = error
+  EXPECT_EQ(-0.5, cmd);
+
+  // If call again with same arguments
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect the integration do it part doubling the command
+  EXPECT_EQ(-1.0, cmd);
+
+  // Call again with no error
+  cmd = pid.computeCommand(0.0, ros::Duration(1.0));
+  // Expect the integral part to keep the previous command because ensure error = 0
+  EXPECT_EQ(-1.0, cmd);
+
+  // Double check that the integral contribution keep the previous command
+  cmd = pid.computeCommand(0.0, ros::Duration(1.0));
+  EXPECT_EQ(-1.0, cmd);
+
+  // Finally call again with positive error to see if the command changes in the opposite direction
+  cmd = pid.computeCommand(1.0, ros::Duration(1.0));
+  // Expect that the command is cleared since error = -1 * previous command, i-gain = 1, dt = 1
+  EXPECT_EQ(0.0, cmd);
+}
+
+TEST(CommandTest, derivativeOnlyTest)
+{
+  RecordProperty("description","This test checks that a command is computed correctly using the derivative contribution only with own differentiation (ATTENTION: this test depends on the differentiation scheme).");
+
+  // Set only derivative gain
+  Pid pid(0.0, 0.0, 1.0, 0.0, 0.0);
+  double cmd = 0.0;
+
+  // If initial error = 0, d-gain = 1, dt = 1
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect command = error
+  EXPECT_EQ(-0.5, cmd);
+
+  // If call again with same error
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect command = 0 due to no variation on error
+  EXPECT_EQ(0.0, cmd);
+
+  // If call again with same error and smaller control period
+  cmd = pid.computeCommand(-0.5, ros::Duration(0.1));
+  // Then expect command = 0 again
+  EXPECT_EQ(0.0, cmd);
+
+  // If the error increases,  with dt = 1
+  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
+  // Then expect the command = change in dt
+  EXPECT_EQ(-0.5, cmd);
+
+  // If error decreases, with dt = 1
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect always the command = change in dt (note the sign flip)
+  EXPECT_EQ(0.5, cmd);
+}
+
+TEST(CommandTest, completePIDTest)
+{
+  RecordProperty("description","This test checks that  a command is computed correctly using a complete PID controller (ATTENTION: this test depends on the integral and differentiation schemes).");
+
+  Pid pid(1.0, 1.0, 1.0, 5.0, -5.0);
+  double cmd = 0.0;
+
+  // All contributions are tested, here few tests check that they sum up correctly
+  // If initial error = 0, all gains = 1, dt = 1
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect command = 3x error
+  EXPECT_EQ(-1.5, cmd);
+
+  // If call again with same arguments, no error change, but integration do its part
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  // Then expect command = 3x error againa
+  EXPECT_EQ(-1.5, cmd);
+
+  // If call again increasing the error
+  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
+  // Then expect command equals to p = -1, i = -2.0 (i.e. - 0.5 - 0.5 - 1.0), d = -0.5
+  EXPECT_EQ(-3.5, cmd);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Could be that #40 happened mainly due to 2 things (well, 3, if you count my awkwardness):

1. Lack of tests on command computation, as already requested by @adolfo-rt in #41
2. The `computeCommand` method has two signatures with almost a replica of code within -> Same code in two places requires update in two places -> The chance of making a mistake when updating increases.

In this initial PR both are addressed, there are 2 separated commits to easy the review.

First, in 9dc84fd548c0bd7df9d428cf60594fde24ea2b6d, the coverage of the PID class test suite is increased with the following modification of current tests:

* `zeroITermBadIBoundsTest`: I think that entering `i_max < i_min` should be prevented, or at least warned. A suggested change to avoid bad i-bounds is there commented because it would require a change in the `setGains` method return type to `bool` instead of `void` and the current implementation wouldn't pass the test. Another posibility would be to leave that return type and just throw a warning if `i_max < i_min` is passed.

* `integrationWindupTest`: Now upper and lower bounds are tested.

* integrationWindupZeroGainTest: Untouched. However, it looks to me it is useless with the current integral contribution implementation.

* `gainSettingCopyPIDTest`: Makeup in names for readability + Added test on `reset()` method.

And the following additions, a new set of tests under the name `CommandTest`, hopefully well described with comments:

* `proportionalOnlyTest`, `integralOnlyTest`, `derivativeOnlyTest`: Check that the command computed using each contribution independently is correct. Note that, they depend on the integral and differentiation schemes, and if they change, the tests might not be valid anymore.

* `completePIDTest`: Few checks on the sum up of contributions. Same here, the test depends on the integral and differentiation schemes.

Second, in 7fe5e126b05c4c915ecbb4c143ffef6b8c0ff5c1, only one method does the PID command computation and writes to class members (except for `p_error_last_`), which is the one with the signature that allows users to pass a pre-computed error derivative. The other one calls this method passing the error derivative computed with an internal differentiation scheme. I couldn't find whether this is ROS-style compliant or not, and not sure if it affects critically the performance, but surely it will reduce the chance of making a mistake if the implementation is to be updated again.

PS: I didn't do anything with the DEPRECATED command computation methods.