### PR TITLE
Additional features for the control_toolbox

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(
   )
 
 add_library(${PROJECT_NAME}
+  src/ff.cpp
   src/pid.cpp
   src/pid_gains_setter.cpp
   src/sine_sweep.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(
   )
 
 add_library(${PROJECT_NAME}
+  src/block_wave.cpp
   src/ff.cpp
   src/pid.cpp
   src/pid_gains_setter.cpp

--- a/include/control_toolbox/block_wave.h
+++ b/include/control_toolbox/block_wave.h
@@ -1,0 +1,32 @@
+#ifndef CONTROL_TOOLBOX__BLOCKWAVE_H
+#define CONTROL_TOOLBOX__BLOCKWAVE_H
+
+#include <ros/ros.h>
+#include <math.h>
+
+namespace control_toolbox 
+{
+	class BlockWave
+	{
+		public:
+			BlockWave();
+			~BlockWave();
+			bool init(double frequency, double dutyCycle, double amplitude);
+			double update(double time);
+			
+		private:
+			double frequency_;			
+			double duty_cycle_;
+			double amplitude_;
+			
+			double cmd_;
+			
+			double period_;
+			double up_time_;
+			double down_time_;
+			double threshold_;
+	};	
+}
+
+#endif
+

--- a/include/control_toolbox/ff.h
+++ b/include/control_toolbox/ff.h
@@ -1,0 +1,50 @@
+#ifndef CONTROL_TOOLBOX__FF_H
+#define CONTROL_TOOLBOX__FF_H
+
+#include <ros/ros.h>
+
+using namespace ros;
+
+namespace control_toolbox 
+{
+	template <typename T> int sgn(T val) {
+    return (T(0) < val) - (val < T(0));
+	}
+	
+	struct Gains
+	{
+		// Optional constructor for passing in values
+		Gains(double v, double c)
+		: v_gain_(v),
+		c_gain_(c),
+		c_gain_pos_(c),
+		c_gain_neg_(c)
+		{}
+		// Default constructor
+		Gains() {}
+		double v_gain_;  /**< Viscus gain. */
+		double c_gain_;  /**< Columb gain. */
+		double c_gain_pos_;  /**< Bi-directional Columb gain. */
+		double c_gain_neg_;  /**< Bi-directional Columb gain. */
+	};
+  
+	class Ff
+	{
+		public:
+			Ff() {};
+			~Ff() {};
+			
+			bool init(const NodeHandle &node);
+			double computeCommand(double input, Duration dt);
+			double computeCommand(double input, double input_dot, Duration dt);
+			
+		private:
+			Gains gains_;
+			double input_dot;
+			double p_input_last_;
+			bool c_bi_directional_;
+			
+	};
+}
+
+#endif

--- a/src/block_wave.cpp
+++ b/src/block_wave.cpp
@@ -1,0 +1,50 @@
+#include <control_toolbox/block_wave.h>
+
+namespace control_toolbox 
+{
+		BlockWave::BlockWave()
+		{
+			frequency_ = 0.0;			
+			duty_cycle_ = 0.0;
+			amplitude_ = 0.0;
+			
+			cmd_ = 0.0;
+			
+			period_ = 0.0;
+			up_time_ = 0.0;
+			down_time_ = 0.0;
+			threshold_ = 1.0;
+		}
+		
+		BlockWave::~BlockWave()
+		{}
+		
+		bool BlockWave::init(double frequency, double dutyCycle, double amplitude)
+		{
+			frequency_ = frequency;
+			duty_cycle_ = dutyCycle;
+			amplitude_ = amplitude;
+			
+			cmd_ = 0.0;
+			
+			period_ = 1.0/frequency_;
+			up_time_ = period_ * duty_cycle_;
+			down_time_ = period_ - up_time_;
+			threshold_ = sin(2.0*M_PI*frequency_*(down_time_/4.0));
+			return true;
+		}
+		
+		double BlockWave::update(double time)
+		{
+			double sin_value = sin(2.0*M_PI*frequency_*(time + down_time_/2.0));
+			
+			if(sin_value > 0 && sin_value > threshold_)
+				cmd_ = amplitude_;
+			else if(sin_value < 0 && sin_value < -threshold_)
+				cmd_ = -amplitude_;
+			else
+				cmd_ = 0;
+			
+			return cmd_;
+		}
+}

--- a/src/ff.cpp
+++ b/src/ff.cpp
@@ -1,0 +1,67 @@
+#include <control_toolbox/ff.h>
+
+using namespace std;
+using namespace ros;
+
+namespace control_toolbox 
+{
+	bool Ff::init(const ros::NodeHandle &node)
+	{
+		ros::NodeHandle nh(node);		
+
+		// Load Ff gains from parameter server
+		nh.param("v", gains_.v_gain_, 0.0);
+		nh.param("c", gains_.c_gain_, 0.0);
+		
+		c_bi_directional_ = false;
+			
+		bool pos_def = nh.getParam("c_pos", gains_.c_gain_pos_);
+		bool neg_def = nh.getParam("c_neg", gains_.c_gain_neg_);
+		if (!pos_def || !neg_def)
+		{
+			gains_.c_gain_pos_ = 0;
+			gains_.c_gain_neg_ = 0;
+		}
+		else
+			c_bi_directional_ = true;
+		
+		p_input_last_ = 0.0;
+
+		return true;
+	}
+	
+	double Ff::computeCommand(double input, Duration dt)
+	{
+		//ROS_INFO("ff:: input: %f",input);
+		if (dt.toSec() > 0.0) // Calculate the derivative error
+		{
+			input_dot = (input - p_input_last_) / dt.toSec();
+			p_input_last_ = input;
+		}
+		else
+		 input_dot = 0.0;
+
+		return computeCommand(input, input_dot, dt);
+	}
+	
+	double Ff::computeCommand(double input, double input_dot, Duration dt)
+	{		
+		double v_term = gains_.v_gain_*input;
+		double c_term;
+		
+		if(c_bi_directional_)
+		{
+			if(sgn(input_dot) > 0)
+				c_term = gains_.c_gain_pos_*sgn(input_dot);
+			else
+				c_term = gains_.c_gain_neg_*sgn(input_dot);	
+		}
+		else
+			c_term = gains_.c_gain_*sgn(input_dot);	 
+		
+		double cmd_ = v_term + c_term;
+		//ROS_INFO("ff:: cmd_: %f",cmd_);
+			
+		return cmd_;
+	}
+}


### PR DESCRIPTION
Added a generic feed forward tool and a block wave signal source tool.
- Feed forward: This implements a simple viscous and Columb friction model to compute the command effort. This can be used in addition to the PID tool in several controllers.
- Block wave: This tool generates a block wave signal that can be used for the feed forward identification procedure. Moreover it can be used to test a system by essentially being equivalent to the application of successive steps.
