### PR TITLE
changed the range of dynamic reconfigure to allow negative ones

### DIFF
--- a/cfg/Parameters.cfg
+++ b/cfg/Parameters.cfg
@@ -40,9 +40,9 @@ PACKAGE='control_toolbox'
 
 def generate(gen):
 	#        Name            Type    Level  Description      Default  Min  Max
-	gen.add( "p" ,      double_t, 1,"Proportional gain.", 10.0 , 0 , 100000)
-	gen.add( "i" ,      double_t, 1,"Integral gain.",     0.1 , 0 , 1000)
-	gen.add( "d" ,      double_t, 1,"Derivative gain.",   1.0 , 0 , 1000)
+	gen.add( "p" ,      double_t, 1,"Proportional gain.", 10.0 , -100000 , 100000)
+	gen.add( "i" ,      double_t, 1,"Integral gain.",     0.1 , -1000 , 1000)
+	gen.add( "d" ,      double_t, 1,"Derivative gain.",   1.0 , -1000 , 1000)
 	gen.add( "i_clamp_min" , double_t, 1,"Min bounds for the integral windup",  -10.0 , -1000 , 0)
 	gen.add( "i_clamp_max" , double_t, 1,"Max bounds for the integral windup",   10.0 , 0 , 1000)
 	                 # PkgName  #NodeName         #Prefix for generated .h include file, e.g. ParametersConfig.py


### PR DESCRIPTION
dynamic reconfigure only allows setting positive values for PID gains although negative values can be set using setGain.