### PR TITLE
Remove rosbuild support related error handling in cfg

### DIFF
--- a/cfg/Parameters.cfg
+++ b/cfg/Parameters.cfg
@@ -34,31 +34,19 @@
 #*  POSSIBILITY OF SUCH DAMAGE.
 #*********************************************************************/
 
-#   Author: Dave Coleman
+#   Authors: Dave Coleman, Igor Napolskikh
 #   Desc:   Allows PID parameters, etc to be tuned in realtime using dynamic reconfigure
 PACKAGE='control_toolbox'
 
-def generate(gen):
-	#        Name            Type    Level  Description      Default  Min  Max
-	gen.add( "p" ,      double_t, 1,"Proportional gain.", 10.0 , -100000 , 100000)
-	gen.add( "i" ,      double_t, 1,"Integral gain.",     0.1 , -1000 , 1000)
-	gen.add( "d" ,      double_t, 1,"Derivative gain.",   1.0 , -1000 , 1000)
-	gen.add( "i_clamp_min" , double_t, 1,"Min bounds for the integral windup",  -10.0 , -1000 , 0)
-	gen.add( "i_clamp_max" , double_t, 1,"Max bounds for the integral windup",   10.0 , 0 , 1000)
-	gen.add( "antiwindup" , bool_t, 1,"Antiwindup.",   False)
-	                 # PkgName  #NodeName         #Prefix for generated .h include file, e.g. ParametersConfig.py
-	exit(gen.generate(PACKAGE, "control_toolbox", "Parameters"))
+from dynamic_reconfigure.parameter_generator_catkin import *
+gen = ParameterGenerator()
 
-# try catkin generator first
-try:
-	from dynamic_reconfigure.parameter_generator_catkin import *
-	gen = ParameterGenerator()
-	generate(gen)
-# reason for catching IndexError
-# parameter_generator_catkin expects 4 arguments while rosbuild only passes in 2
-# not thrilled with this solution
-except IndexError:
-	print 'ERROR', PACKAGE, 'Parameters.cfg failed using parameter_generator_catkin, using rosbuild instead'
-	from dynamic_reconfigure.parameter_generator import *
-	gen = ParameterGenerator()
-	generate(gen)
+#        Name            Type      Level  Description                           Default   Min       Max
+gen.add( "p" ,           double_t, 1,     "Proportional gain.",                 10.0,     -100000,  100000)
+gen.add( "i" ,           double_t, 1,     "Integral gain.",                     0.1,      -1000,    1000)
+gen.add( "d" ,           double_t, 1,     "Derivative gain.",                   1.0,      -1000,    1000)
+gen.add( "i_clamp_min" , double_t, 1,     "Min bounds for the integral windup", -10.0,    -1000,    0)
+gen.add( "i_clamp_max" , double_t, 1,     "Max bounds for the integral windup", 10.0,     0,        1000)
+                 # PkgName  #NodeName         #Prefix for generated .h include file, e.g. ParametersConfig.py
+exit(gen.generate(PACKAGE, "control_toolbox", "Parameters"))
+

--- a/cfg/Parameters.cfg
+++ b/cfg/Parameters.cfg
@@ -47,6 +47,7 @@ gen.add( "i" ,           double_t, 1,     "Integral gain.",                     
 gen.add( "d" ,           double_t, 1,     "Derivative gain.",                   1.0,      -1000,    1000)
 gen.add( "i_clamp_min" , double_t, 1,     "Min bounds for the integral windup", -10.0,    -1000,    0)
 gen.add( "i_clamp_max" , double_t, 1,     "Max bounds for the integral windup", 10.0,     0,        1000)
+gen.add( "antiwindup" ,  bool_t,   1,     "Antiwindup.",                        False)
                  # PkgName  #NodeName         #Prefix for generated .h include file, e.g. ParametersConfig.py
 exit(gen.generate(PACKAGE, "control_toolbox", "Parameters"))
 


### PR DESCRIPTION
Parameters.cfg should now be compatible with Python2 and Python3, alternative to [PR 56](https://github.com/ros-controls/control_toolbox/pull/56).