### PR TITLE
rollback API changes in PID class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,9 @@ add_library(${PROJECT_NAME}
   src/sinusoid.cpp
   src/limited_proxy.cpp
   )
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg) # wait for dynamic reconfigure
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(${PROJECT_NAME} ${TinyXML_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-
-add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp) # wait for msgs
 
 if(CATKIN_ENABLE_TESTING)
   # Tests

--- a/include/control_toolbox/pid.h
+++ b/include/control_toolbox/pid.h
@@ -123,8 +123,17 @@ public:
    */
   struct Gains
   {
+    // Optional constructor for passing in values without antiwindup
+    Gains(double p, double i, double d, double i_max, double i_min)
+      : p_gain_(p),
+        i_gain_(i),
+        d_gain_(d),
+        i_max_(i_max),
+        i_min_(i_min),
+        antiwindup_(false)
+    {}
     // Optional constructor for passing in values
-    Gains(double p, double i, double d, double i_max, double i_min, bool antiwindup = false)
+    Gains(double p, double i, double d, double i_max, double i_min, bool antiwindup)
       : p_gain_(p),
         i_gain_(i),
         d_gain_(d),

--- a/include/control_toolbox/pid.h
+++ b/include/control_toolbox/pid.h
@@ -124,7 +124,7 @@ public:
   struct Gains
   {
     // Optional constructor for passing in values
-    Gains(double p, double i, double d, double i_max, double i_min, bool antiwindup)
+    Gains(double p, double i, double d, double i_max, double i_min, bool antiwindup = false)
       : p_gain_(p),
         i_gain_(i),
         d_gain_(d),
@@ -183,7 +183,7 @@ public:
    * \param i_max The max integral windup.
    * \param i_min The min integral windup.
    */
-  void initPid(double p, double i, double d, double i_max, double i_min, bool antiwindup);
+  void initPid(double p, double i, double d, double i_max, double i_min, bool antiwindup = false);
 
   /*!
    * \brief Zeros out Pid values and initialize Pid-gains and integral term limits
@@ -195,6 +195,7 @@ public:
    * \param i_max The max integral windup.
    * \param i_min The min integral windup.
    */
+  void initPid(double p, double i, double d, double i_max, double i_min, const ros::NodeHandle& /*node*/);
   void initPid(double p, double i, double d, double i_max, double i_min, bool antiwindup, const ros::NodeHandle& /*node*/);
 
   /*!
@@ -242,6 +243,7 @@ public:
    * \param i_max The max integral windup.
    * \param i_min The min integral windup.
    */
+  void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup);
 
   /*!
@@ -258,7 +260,7 @@ public:
    * \param i_max The max integral windup.
    * \param i_min The min integral windup.
    */
-  void setGains(double p, double i, double d, double i_max, double i_min, bool antiwindup);
+  void setGains(double p, double i, double d, double i_max, double i_min, bool antiwindup = false);
 
   /*!
    * \brief Set PID gains for the controller.

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -72,7 +72,7 @@ Pid::~Pid()
 void Pid::initPid(double p, double i, double d, double i_max, double i_min,
   const ros::NodeHandle& /*node*/)
 {
-  initPid(p, i, d, i_max, i_min, false);
+  initPid(p, i, d, i_max, i_min);
 
   // Create node handle for dynamic reconfigure
   ros::NodeHandle nh(DEFAULT_NAMESPACE);

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -69,6 +69,16 @@ Pid::~Pid()
 {
 }
 
+void Pid::initPid(double p, double i, double d, double i_max, double i_min,
+  const ros::NodeHandle& /*node*/)
+{
+  initPid(p, i, d, i_max, i_min, false);
+
+  // Create node handle for dynamic reconfigure
+  ros::NodeHandle nh(DEFAULT_NAMESPACE);
+  initDynamicReconfig(nh);
+}
+
 void Pid::initPid(double p, double i, double d, double i_max, double i_min, bool antiwindup,
   const ros::NodeHandle& /*node*/)
 {
@@ -190,6 +200,12 @@ void Pid::reset()
   i_error_ = 0.0;
   d_error_ = 0.0;
   cmd_ = 0.0;
+}
+
+void Pid::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
+{
+  bool antiwindup;
+  getGains(p, i, d, i_max, i_min, antiwindup);
 }
 
 void Pid::getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup)


### PR DESCRIPTION
I noticed some API changes have been introduced in #52 when compiling our code for kinetic.

This will rollback the API changes without changing functionality.
See discussion in #34 

@paulbovbel @bmagyar 