### PR TITLE
Add control_msgs to CATKIN_DEPENDS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,11 @@ generate_messages(
 catkin_package(
   DEPENDS TinyXML
   CATKIN_DEPENDS
-    roscpp
+    control_msgs
     dynamic_reconfigure
-    realtime_tools
     message_runtime
+    realtime_tools
+    roscpp
     std_msgs
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}


### PR DESCRIPTION
Needed because of the usage here:

https://github.com/ros-controls/control_toolbox/blob/ba1100638a48a461e4e642150f4ae666303e3ecc/include/control_toolbox/pid.h#L40