### PR TITLE
fixed an antiwindup bug

### DIFF
--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -42,6 +42,7 @@
 #include <tinyxml.h>
 
 #include <boost/algorithm/clamp.hpp>
+#include <boost/algorithm/minmax.hpp>
 
 namespace control_toolbox {
 
@@ -335,12 +336,11 @@ double Pid::computeCommand(double error, double error_dot, ros::Duration dt)
   // Calculate the integral of the position error
   i_error_ += dt.toSec() * p_error_;
 
-  if(gains.antiwindup_)
+  if(gains.antiwindup_ && gains.i_gain_!=0)
   {
     // Prevent i_error_ from climbing higher than permitted by i_max_/i_min_
-    i_error_ = boost::algorithm::clamp(i_error_,
-                                       gains.i_min_ / std::abs(gains.i_gain_),
-                                       gains.i_max_ / std::abs(gains.i_gain_));
+    boost::tuple<double, double> bounds = boost::minmax<double>(gains.i_min_ / gains.i_gain_, gains.i_max_ / gains.i_gain_);
+    i_error_ = boost::algorithm::clamp(i_error_, bounds.get<0>(), bounds.get<1>());
   }
 
   // Calculate integral contribution to command

--- a/test/pid_tests.cpp
+++ b/test/pid_tests.cpp
@@ -100,25 +100,25 @@ TEST(ParameterTest, negativeIntegrationAntiwindupTest)
 {
   RecordProperty("description","This test succeeds if the integral error is prevented from winding up when i_gain < 0");
 
-  double i_gain = -2.0;
-  double i_min = -1.0;
-  double i_max = 1.0;
+  double i_gain = -2.5;
+  double i_min = -0.2;
+  double i_max = 0.5;
   Pid pid(0.0, i_gain, 0.0, i_max, i_min, true);
 
   double cmd = 0.0;
   double pe,ie,de;
 
-  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-  EXPECT_EQ(1.0, cmd);
+  cmd = pid.computeCommand(0.1, ros::Duration(1.0));
+  EXPECT_EQ(-0.2, cmd);
 
-  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-  EXPECT_EQ(1.0, cmd);
+  cmd = pid.computeCommand(0.1, ros::Duration(1.0));
+  EXPECT_EQ(-0.2, cmd);
 
-  cmd = pid.computeCommand(0.5, ros::Duration(1.0));
-  EXPECT_EQ(0.0, cmd);
+  cmd = pid.computeCommand(-0.05, ros::Duration(1.0));
+  EXPECT_EQ(-0.075, cmd);
 
-  cmd = pid.computeCommand(-1.0, ros::Duration(1.0));
-  EXPECT_EQ(1.0, cmd);
+  cmd = pid.computeCommand(0.1, ros::Duration(1.0));
+  EXPECT_EQ(-0.2, cmd);
 }
 
 TEST(ParameterTest, gainSettingCopyPIDTest)


### PR DESCRIPTION
If gains.i_gain_ < 0 and std::abs(gains.i_min_) != std::abs(gains.i_max_), there would be a bug.  
For example: i_error_ = 0.1, gains.i_gain_ = -2.5, gains.i_min_ = -0.2, gains.i_max_ = 0.5.  
Then the calculated i_term would be -0.25, which is out of the range [-0.2, 0.5]