### PR TITLE
add erand48() implementation on windows

### DIFF
--- a/src/dither.cpp
+++ b/src/dither.cpp
@@ -36,14 +36,19 @@
 
 #include <control_toolbox/dither.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <random>
-#include <iostream>
-std:: default_random_engine generator;
-std::uniform_real_distribution<double> distr(0.0,1.0);
+
 double erand48(unsigned short xsubi[3])
 {
-  return distr(generator);
+  // following instructions from https://isocpp.org/files/papers/n3551.pdf
+
+  std::random_device rdev{};
+  std::default_random_engine generator{rdev()};
+
+  // uniform distribution on the interval [0.0, 1.0)
+  std::uniform_real_distribution<double> distribution(0.0, 1.0);
+  return distribution(generator);
 }
 #endif
 

--- a/src/dither.cpp
+++ b/src/dither.cpp
@@ -36,6 +36,17 @@
 
 #include <control_toolbox/dither.h>
 
+#ifdef WIN32
+#include <random>
+#include <iostream>
+std:: default_random_engine generator;
+std::uniform_real_distribution<double> distr(0.0,1.0);
+double erand48(unsigned short xsubi[3])
+{
+  return distr(generator);
+}
+#endif
+
 namespace control_toolbox {
 
 Dither::Dither() : amplitude_(0), has_saved_value_(false)


### PR DESCRIPTION
`erand48()` is not available on Windows. to work around this, add `erand48` definition using functions from STL's `random` library

this is a bit different from the behavior on Linux since this implementation with STL's functions would yield (actually) random numbers since we're not using the pre-defined [seed](https://github.com/ros-controls/control_toolbox/blob/kinetic-devel/include/control_toolbox/dither.h#L96).

However, judging from the code, we wonder if the original seed is necessary, would making these truly random cause any problem?