### PR TITLE
update .travis.yml to exclude kinetic build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ env:
   global:
     - ROS_PARALLEL_TEST_JOBS=-j1
   matrix:
-    - ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.github.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
-    - ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.github.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
     - ROS_DISTRO=melodic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.github.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
     - ROS_DISTRO=melodic  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.github.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
   


### PR DESCRIPTION
update .travis.yml to exclude kinetic build

p.s., the default branch for `control_toolbox` could/should be updated to `melodic-devel`, instead of `kinetic-devel`