### PR TITLE
Allow smoother resets

### DIFF
--- a/include/control_toolbox/pid.h
+++ b/include/control_toolbox/pid.h
@@ -245,6 +245,11 @@ public:
   void reset();
 
   /*!
+   * \brief Reset the state of this PID controller. Allows setting d_error & i_error initial value to support cases where pid is activated with some initial command.
+   */
+  void reset(double d_error, double i_error);
+
+  /*!
    * \brief Get PID gains for the controller.
    * \param p  The proportional gain.
    * \param i  The integral gain.
@@ -395,6 +400,7 @@ private:
   boost::shared_ptr<realtime_tools::RealtimePublisher<control_msgs::PidState> > state_publisher_;
   bool publish_state_;
 
+  bool valid_p_error_last_; /**< Is saved position state valid for derivative state calculation */
   double p_error_last_; /**< _Save position state for derivative state calculation. */
   double p_error_; /**< Position error. */
   double i_error_; /**< Integral of position error. */

--- a/include/control_toolbox/pid.h
+++ b/include/control_toolbox/pid.h
@@ -245,7 +245,7 @@ public:
   void reset();
 
   /*!
-   * \brief Reset the state of this PID controller. Allows setting d_error & i_error initial value to support cases where pid is activated with some initial command.
+   * \brief Reset the state of this PID controller. Allows setting d_error & i_error initial value to support cases where PID is activated with some initial command.
    */
   void reset(double d_error, double i_error);
 

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -306,14 +306,16 @@ double Pid::computeCommand(double error, ros::Duration dt)
 {
 
   if (dt == ros::Duration(0.0) || std::isnan(error) || std::isinf(error))
-    return cmd_;
+    return 0.0;
 
   double error_dot = d_error_;
 
   // Calculate the derivative error
-  if (dt.toSec() > 0.0 && valid_p_error_last_)
+  if (dt.toSec() > 0.0)
   {
-    error_dot = (error - p_error_last_) / dt.toSec();
+    if (valid_p_error_last_) {
+      error_dot = (error - p_error_last_) / dt.toSec();
+    }
     p_error_last_ = error;
     valid_p_error_last_ = true;
   }
@@ -336,7 +338,7 @@ double Pid::computeCommand(double error, double error_dot, ros::Duration dt)
   d_error_ = error_dot;
 
   if (dt == ros::Duration(0.0) || std::isnan(error) || std::isinf(error) || std::isnan(error_dot) || std::isinf(error_dot))
-    return cmd_;
+    return 0.0;
 
   // Calculate proportional contribution to command
   p_term = gains.p_gain_ * p_error_;

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -196,11 +196,18 @@ void Pid::initDynamicReconfig(ros::NodeHandle &node)
 
 void Pid::reset()
 {
+  reset(0.0, 0.0);
+  valid_p_error_last_ = true;
+}
+
+void Pid::reset(double d_error, double i_error)
+{
   p_error_last_ = 0.0;
   p_error_ = 0.0;
-  i_error_ = 0.0;
-  d_error_ = 0.0;
+  i_error_ = i_error;
+  d_error_ = d_error;
   cmd_ = 0.0;
+  valid_p_error_last_ = false;
 }
 
 void Pid::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
@@ -299,15 +306,16 @@ double Pid::computeCommand(double error, ros::Duration dt)
 {
 
   if (dt == ros::Duration(0.0) || std::isnan(error) || std::isinf(error))
-    return 0.0;
+    return cmd_;
 
   double error_dot = d_error_;
 
   // Calculate the derivative error
-  if (dt.toSec() > 0.0)
+  if (dt.toSec() > 0.0 && valid_p_error_last_)
   {
     error_dot = (error - p_error_last_) / dt.toSec();
     p_error_last_ = error;
+    valid_p_error_last_ = true;
   }
 
   return computeCommand(error, error_dot, dt);
@@ -328,7 +336,7 @@ double Pid::computeCommand(double error, double error_dot, ros::Duration dt)
   d_error_ = error_dot;
 
   if (dt == ros::Duration(0.0) || std::isnan(error) || std::isinf(error) || std::isnan(error_dot) || std::isinf(error_dot))
-    return 0.0;
+    return cmd_;
 
   // Calculate proportional contribution to command
   p_term = gains.p_gain_ * p_error_;

--- a/test/pid_tests.cpp
+++ b/test/pid_tests.cpp
@@ -273,6 +273,8 @@ TEST(CommandTest, resetWithInitialValuesTest)
   pid.reset(1, 0); // set initial d-error=1 & i-error=0
   cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
   EXPECT_EQ(0, cmd);
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  EXPECT_EQ(-1.5, cmd); // p_term=0.5, i_term=-1, d_term=0
 
   // If initial i_error = 1, all gains = 1, dt = 1
   pid.reset(0, -1); // set initial d-error=0 & i-error=1

--- a/test/pid_tests.cpp
+++ b/test/pid_tests.cpp
@@ -257,6 +257,30 @@ TEST(CommandTest, proportionalOnlyTest)
   EXPECT_EQ(0.5, cmd);
 }
 
+TEST(CommandTest, resetWithInitialValuesTest)
+{
+  RecordProperty("description","This test checks that resetting PID with initial i_error & d_error values work.");
+
+  Pid pid(1.0, 1.0, 1.0, 5.0, -5.0);
+  double cmd = 0.0;
+
+  // If initial d_error = 0, all gains = 1, dt = 1
+  pid.reset(0, 0); // set initial d-error=0 & i-error=0
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  EXPECT_EQ(-1, cmd);
+
+  // If initial d_error = 1, all gains = 1, dt = 1
+  pid.reset(1, 0); // set initial d-error=1 & i-error=0
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  EXPECT_EQ(0, cmd);
+
+  // If initial i_error = 1, all gains = 1, dt = 1
+  pid.reset(0, -1); // set initial d-error=0 & i-error=1
+  cmd = pid.computeCommand(-0.5, ros::Duration(1.0));
+  EXPECT_EQ(-2, cmd);
+}
+
+
 TEST(CommandTest, integralOnlyTest)
 {
   RecordProperty("description","This test checks that a command is computed correctly using the integral contribution only (ATTENTION: this test depends on the integration scheme).");


### PR DESCRIPTION
1. Currently after a reset (or init), since p_error_last is_ set to 0, the first computeCommand is calculating
a false large derivative error. Proposed fix: only calculate error_dot if p_error_last_ contains a real value.

2. Allow setting initial i_error. This allows PID to be used in a smoother manner in systems switching from
manual to automatic modes. [Reference](http://brettbeauregard.com/blog/2011/04/improving-the-beginner%E2%80%99s-pid-initialization/)

3. Improve cases where dt==0 or invalid errors were given (return last cmd_ instead of 0)