### PR TITLE
Remove Extra include of iostream

### DIFF
--- a/include/control_toolbox/sinusoid.h
+++ b/include/control_toolbox/sinusoid.h
@@ -37,7 +37,6 @@
 #ifndef CONTROL_TOOLBOX__SINUSOID_H_
 #define CONTROL_TOOLBOX__SINUSOID_H_
 
-#include <iostream>
 #include <tinyxml.h>
 
 namespace control_toolbox


### PR DESCRIPTION
`sinusoid.h` includes `<iostream>`, but it is only used in `sinusoid.cpp`. 
https://github.com/ros-controls/control_toolbox/blob/87c3ca1efedaa5740b517ac706c27d56ee6b3559/src/sinusoid.cpp#L39

This PR removes the extra include from the header since it's unused there.