### PR TITLE
Created a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(control_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(realtime_tools REQUIRED)
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/dither.cpp
   src/limited_proxy.cpp
   src/pid.cpp


### PR DESCRIPTION
Is there any reason why control_toolbox is not a shared library ?

Signed-off-by: ahcorde <ahcorde@gmail.com>