### PR TITLE
Added a prefix option to parameters

### DIFF
--- a/include/control_toolbox/pid.hpp
+++ b/include/control_toolbox/pid.hpp
@@ -194,11 +194,12 @@ public:
    * \param i_min The min integral windup.
    */
   void initPid(
-    double p, double i, double d, double i_max, double i_min, NodeParamsIfacePtr node_param_iface);
+    double p, double i, double d, double i_max, double i_min, NodeParamsIfacePtr node_param_iface,
+    std::string parameter_prefix = "");
 
   void initPid(
     double p, double i, double d, double i_max, double i_min, bool antiwindup,
-    NodeParamsIfacePtr node_param_iface);
+    NodeParamsIfacePtr node_param_iface, std::string parameter_prefix = "");
 
   /*!
    * \brief Initialize real-time pid state publisher
@@ -336,6 +337,8 @@ private:
   double cmd_;          /**< Command to send. */
 
   NodeParamsIfacePtr node_param_iface_;
+
+  std::string parameter_prefix_;
 
   using OnSetParamsCallbackPtr = rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr;
   OnSetParamsCallbackPtr parameter_callback_;

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -88,19 +88,13 @@ void Pid::initPid(
   initPid(p, i, d, i_max, i_min, gains.antiwindup_, node_param_iface, parameter_prefix);
 }
 
-bool endsWith(const std::string & str, const std::string & suffix)
-{
-  return str.size() >= suffix.size() &&
-         0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
-}
-
 void Pid::initPid(
   double p, double i, double d, double i_max, double i_min, bool antiwindup,
   NodeParamsIfacePtr node_param_iface, std::string parameter_prefix)
 
 {
   parameter_prefix_ = parameter_prefix;
-  if (!parameter_prefix_.empty() && !endsWith(parameter_prefix_, ".")) {
+  if (!parameter_prefix_.empty() && (parameter_prefix_.back() != '.')) {
     parameter_prefix_ = parameter_prefix_ + std::string(".");
   }
   initPid(p, i, d, i_max, i_min, antiwindup);

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -91,7 +91,6 @@ void Pid::initPid(
 void Pid::initPid(
   double p, double i, double d, double i_max, double i_min, bool antiwindup,
   NodeParamsIfacePtr node_param_iface, std::string parameter_prefix)
-
 {
   parameter_prefix_ = parameter_prefix;
   if (!parameter_prefix_.empty() && (parameter_prefix_.back() != '.')) {

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -88,9 +88,10 @@ void Pid::initPid(
   initPid(p, i, d, i_max, i_min, gains.antiwindup_, node_param_iface, parameter_prefix);
 }
 
-bool endsWith(const std::string& str, const std::string& suffix)
+bool endsWith(const std::string & str, const std::string & suffix)
 {
-   return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
+  return str.size() >= suffix.size() &&
+         0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
 }
 
 void Pid::initPid(
@@ -98,8 +99,8 @@ void Pid::initPid(
   NodeParamsIfacePtr node_param_iface, std::string parameter_prefix)
 {
   parameter_prefix_ = parameter_prefix;
-  if (!parameter_prefix_.empty() and !endsWith(parameter_prefix_, ".")) {
-    parameter_prefix_ =  parameter_prefix_ + std::string(".");
+  if (!parameter_prefix_.empty() && !endsWith(parameter_prefix_, ".")) {
+    parameter_prefix_ = parameter_prefix_ + std::string(".");
   }
   initPid(p, i, d, i_max, i_min, antiwindup);
 
@@ -192,11 +193,11 @@ void Pid::setGains(const Gains & gains)
   if (node_param_iface_) {
     node_param_iface_->set_parameters(
       {rclcpp::Parameter(parameter_prefix_ + "p", gains.p_gain_),
-       rclcpp::Parameter(parameter_prefix_ + "i", gains.i_gain_),
-       rclcpp::Parameter(parameter_prefix_ + "d", gains.d_gain_),
-       rclcpp::Parameter(parameter_prefix_ + "i_clamp_max", gains.i_max_),
-       rclcpp::Parameter(parameter_prefix_ + "i_clamp_min", gains.i_min_),
-       rclcpp::Parameter(parameter_prefix_ + "antiwindup", gains.antiwindup_)});
+        rclcpp::Parameter(parameter_prefix_ + "i", gains.i_gain_),
+        rclcpp::Parameter(parameter_prefix_ + "d", gains.d_gain_),
+        rclcpp::Parameter(parameter_prefix_ + "i_clamp_max", gains.i_max_),
+        rclcpp::Parameter(parameter_prefix_ + "i_clamp_min", gains.i_min_),
+        rclcpp::Parameter(parameter_prefix_ + "antiwindup", gains.antiwindup_)});
   }
 }
 
@@ -301,19 +302,20 @@ void Pid::printValues(const rclcpp::Logger & logger)
 {
   Gains gains = getGains();
 
-  RCLCPP_INFO_STREAM(logger,
+  RCLCPP_INFO_STREAM(
+    logger,
     "Current Values of PID Class:\n" <<
-    "  P Gain:       " << gains.p_gain_ << "\n" <<
-    "  I Gain:       " << gains.i_gain_ << "\n" <<
-    "  D Gain:       " << gains.d_gain_ << "\n" <<
-    "  I_Max:        " << gains.i_max_ << "\n" <<
-    "  I_Min:        " << gains.i_min_ << "\n" <<
-    "  Antiwindup:   " << gains.antiwindup_ << "\n" <<
-    "  P_Error_Last: " << p_error_last_ << "\n" <<
-    "  P_Error:      " << p_error_ << "\n" <<
-    "  I_Error:      " << i_error_ << "\n" <<
-    "  D_Error:      " << d_error_ << "\n" <<
-    "  Command:      " << cmd_
+      "  P Gain:       " << gains.p_gain_ << "\n" <<
+      "  I Gain:       " << gains.i_gain_ << "\n" <<
+      "  D Gain:       " << gains.d_gain_ << "\n" <<
+      "  I_Max:        " << gains.i_max_ << "\n" <<
+      "  I_Min:        " << gains.i_min_ << "\n" <<
+      "  Antiwindup:   " << gains.antiwindup_ << "\n" <<
+      "  P_Error_Last: " << p_error_last_ << "\n" <<
+      "  P_Error:      " << p_error_ << "\n" <<
+      "  I_Error:      " << i_error_ << "\n" <<
+      "  D_Error:      " << d_error_ << "\n" <<
+      "  Command:      " << cmd_
   );
 }
 

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -97,6 +97,7 @@ bool endsWith(const std::string & str, const std::string & suffix)
 void Pid::initPid(
   double p, double i, double d, double i_max, double i_min, bool antiwindup,
   NodeParamsIfacePtr node_param_iface, std::string parameter_prefix)
+
 {
   parameter_prefix_ = parameter_prefix;
   if (!parameter_prefix_.empty() && !endsWith(parameter_prefix_, ".")) {
@@ -330,17 +331,17 @@ void Pid::setParameterEventCallback()
 
       for (auto & parameter : parameters) {
         const std::string param_name = parameter.get_name();
-        if (param_name == "p") {
+        if (param_name == (parameter_prefix_ + "p")) {
           gains.p_gain_ = parameter.get_value<double>();
-        } else if (param_name == "i") {
+        } else if (param_name == (parameter_prefix_ + "i" )) {
           gains.i_gain_ = parameter.get_value<double>();
-        } else if (param_name == "d") {
+        } else if (param_name == (parameter_prefix_ + "d")) {
           gains.d_gain_ = parameter.get_value<double>();
-        } else if (param_name == "i_clamp_max") {
+        } else if (param_name == (parameter_prefix_ + "i_clamp_max")) {
           gains.i_max_ = parameter.get_value<double>();
-        } else if (param_name == "i_clamp_min") {
+        } else if (param_name == (parameter_prefix_ + "i_clamp_min")) {
           gains.i_min_ = parameter.get_value<double>();
-        } else if (param_name == "antiwindup") {
+        } else if (param_name == (parameter_prefix_ + "antiwindup")) {
           gains.antiwindup_ = parameter.get_value<bool>();
         } else {
           result.successful = false;


### PR DESCRIPTION
Right now if you try to add two pid controller to the same node parameter server, the parameters are shared for the pid controllers. I added a optional argument to add a prefix to the pid controller

the original code create this parameters:
```
/gazebo_ros2_control:
  antiwindup
  d
  i
  i_clamp_max
  i_clamp_min
  p
```

This will generate something like this:

```
/gazebo_ros2_control:
  slider_to_cart.antiwindup
  slider_to_cart.d
  slider_to_cart.i
  slider_to_cart.i_clamp_max
  slider_to_cart.i_clamp_min
  slider_to_cart.p
  bar.antiwindup
  bar.d
  bar.i
  bar.i_clamp_max
  bar.i_clamp_min
  bar.p
```

Signed-off-by: ahcorde <ahcorde@gmail.com>