### PR TITLE
Added topic_prefix to publisher topic name

### DIFF
--- a/include/control_toolbox/pid.hpp
+++ b/include/control_toolbox/pid.hpp
@@ -206,7 +206,7 @@ public:
    * \param node A pointer to the node.
    */
 
-  void initPublisher(NodePtr node);
+  void initPublisher(NodePtr node, std::string topic_prefix = "");
 
   /*!
    * \brief Reset the state of this PID controller

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -289,19 +289,20 @@ void Pid::printValues(const rclcpp::Logger & logger)
 {
   Gains gains = getGains();
 
-  RCLCPP_INFO_STREAM(logger,
+  RCLCPP_INFO_STREAM(
+    logger,
     "Current Values of PID Class:\n" <<
-    "  P Gain:       " << gains.p_gain_ << "\n" <<
-    "  I Gain:       " << gains.i_gain_ << "\n" <<
-    "  D Gain:       " << gains.d_gain_ << "\n" <<
-    "  I_Max:        " << gains.i_max_ << "\n" <<
-    "  I_Min:        " << gains.i_min_ << "\n" <<
-    "  Antiwindup:   " << gains.antiwindup_ << "\n" <<
-    "  P_Error_Last: " << p_error_last_ << "\n" <<
-    "  P_Error:      " << p_error_ << "\n" <<
-    "  I_Error:      " << i_error_ << "\n" <<
-    "  D_Error:      " << d_error_ << "\n" <<
-    "  Command:      " << cmd_
+      "  P Gain:       " << gains.p_gain_ << "\n" <<
+      "  I Gain:       " << gains.i_gain_ << "\n" <<
+      "  D Gain:       " << gains.d_gain_ << "\n" <<
+      "  I_Max:        " << gains.i_max_ << "\n" <<
+      "  I_Min:        " << gains.i_min_ << "\n" <<
+      "  Antiwindup:   " << gains.antiwindup_ << "\n" <<
+      "  P_Error_Last: " << p_error_last_ << "\n" <<
+      "  P_Error:      " << p_error_ << "\n" <<
+      "  I_Error:      " << i_error_ << "\n" <<
+      "  D_Error:      " << d_error_ << "\n" <<
+      "  Command:      " << cmd_
   );
 }
 

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -122,12 +122,12 @@ void Pid::initPid(double p, double i, double d, double i_max, double i_min, bool
   reset();
 }
 
-void Pid::initPublisher(NodePtr node)
+void Pid::initPublisher(NodePtr node, std::string topic_prefix)
 {
   rclcpp::QoS qos(10);
   qos.reliable().transient_local();
 
-  state_pub_ = node->create_publisher<PidStateMsg>("state", qos);
+  state_pub_ = node->create_publisher<PidStateMsg>(topic_prefix + "/pid_state", qos);
   rt_state_pub_.reset(
     new realtime_tools::RealtimePublisher<control_msgs::msg::PidState>(state_pub_));
 

--- a/test/pid_publisher_tests.cpp
+++ b/test/pid_publisher_tests.cpp
@@ -49,7 +49,7 @@ TEST(PidPublihserTest, PublishTest)
       callback_called = true;
     };
 
-  auto state_sub = node->create_subscription<PidStateMsg>("state", 10, state_callback);
+  auto state_sub = node->create_subscription<PidStateMsg>("pid_state", 10, state_callback);
 
   double command = pid.computeCommand(-0.5, rclcpp::Duration(1, 0));
   EXPECT_EQ(-1.5, command);


### PR DESCRIPTION
Similar idea to the parameter prefix PR https://github.com/ros-controls/control_toolbox/pull/94. In this case the topic name will be the same for all the pids. Adding this argument we can split them in different topics.

Signed-off-by: ahcorde <ahcorde@gmail.com>