### PR TITLE
Increased integral gains & windup limits from +-1000 to +-100000

### DIFF
--- a/cfg/Parameters.cfg
+++ b/cfg/Parameters.cfg
@@ -43,10 +43,10 @@ gen = ParameterGenerator()
 
 #        Name            Type      Level  Description                           Default   Min       Max
 gen.add( "p" ,           double_t, 1,     "Proportional gain.",                 10.0,     -100000,  100000)
-gen.add( "i" ,           double_t, 1,     "Integral gain.",                     0.1,      -1000,    1000)
+gen.add( "i" ,           double_t, 1,     "Integral gain.",                     0.1,      -100000,  100000)
 gen.add( "d" ,           double_t, 1,     "Derivative gain.",                   1.0,      -1000,    1000)
-gen.add( "i_clamp_min" , double_t, 1,     "Min bounds for the integral windup", -10.0,    -1000,    0)
-gen.add( "i_clamp_max" , double_t, 1,     "Max bounds for the integral windup", 10.0,     0,        1000)
+gen.add( "i_clamp_min" , double_t, 1,     "Min bounds for the integral windup", -10.0,    -100000,  0)
+gen.add( "i_clamp_max" , double_t, 1,     "Max bounds for the integral windup", 10.0,     0,        100000)
 gen.add( "antiwindup" ,  bool_t,   1,     "Antiwindup.",                        False)
                  # PkgName  #NodeName         #Prefix for generated .h include file, e.g. ParametersConfig.py
 exit(gen.generate(PACKAGE, "control_toolbox", "Parameters"))


### PR DESCRIPTION
In a recent application we have found that we needed an a integral gain of around 7500 - 10000, which is rather larger than the +-1000 limits enforced by the dynamic reconfigure parameters in `Parameters.cfg`. Whether having an integral gain this high is actually a good idea or not is another matter... but it would be nice to be able to try it out without being constrained by artificial limits :smiley:

This change simply increases the limits of the integral gain from +-1000 to +-100000 which provides ample wiggle room, at the expense of the sliders being harder to fine tune in dynamic reconfigure. Seeing as the P gain limits are already +-100000, I figured this wouldn't be too much of an issue.