### PR TITLE
Fix namespace collision and parameter_callback problems in PidROS

### DIFF
--- a/include/control_toolbox/pid_ros.hpp
+++ b/include/control_toolbox/pid_ros.hpp
@@ -225,6 +225,7 @@ private:
 
   Pid pid_;
   std::string topic_prefix_;
+  std::string param_prefix_;
 };
 
 }  // namespace control_toolbox

--- a/test/pid_parameters_tests.cpp
+++ b/test/pid_parameters_tests.cpp
@@ -227,6 +227,29 @@ TEST(PidParametersTest, GetParametersFromParams)
   ASSERT_EQ(param.get_value<double>(), P);
 }
 
+TEST(PidParametersTest, MultiplePidInstances)
+{
+  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("multiple_pid_instances");
+
+  control_toolbox::PidROS pid_1(node, "PID_1");
+  control_toolbox::PidROS pid_2(node, "PID_2");
+
+  const double P = 1.0;
+  const double I = 2.0;
+  const double D = 3.0;
+  const double I_MAX = 10.0;
+  const double I_MIN = -10.0;
+
+  ASSERT_NO_THROW(pid_1.initPid(P, I, D, I_MAX, I_MIN, false));
+  ASSERT_NO_THROW(pid_2.initPid(P, I, D, I_MAX, I_MIN, true));
+
+  rclcpp::Parameter param_1, param_2;
+  ASSERT_TRUE(node->get_parameter("PID_1.p", param_1));
+  ASSERT_EQ(param_1.get_value<double>(), P);
+  ASSERT_TRUE(node->get_parameter("PID_2.p", param_2));
+  ASSERT_EQ(param_2.get_value<double>(), P);
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This fixes problems in PidROS with using the parameters (reconfiguration fails when the node has extra parameters declared) and with namespacing issues (topic namespace argument can lead to problems if defined deeper than one)