### PR TITLE
Export missing dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin)
 
 ament_export_dependencies(
+  control_msgs
   rclcpp
   rcutils
   realtime_tools)


### PR DESCRIPTION
The library has four dependencies but only three are exported. This produces that packages using anything from `control_toolbox` which uses `control_msgs` is going to fail (`pid_ros.hpp`)

Adding the missing dependency to the ones exported.