### PR TITLE
🔧Fixes and updated on pre-commit hooks and their action.

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -6,9 +6,6 @@ name: Format
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - ros2-master
 
 jobs:
   pre-commit:
@@ -22,4 +19,3 @@ jobs:
     - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual
-        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,14 +42,14 @@ repos:
         args: [--py36-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         args: ["--line-length=99"]
 
   # PyDocStyle
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.2.3
+    rev: 6.3.0
     hooks:
     - id: pydocstyle
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]
@@ -123,7 +123,7 @@ repos:
         exclude: CHANGELOG\.rst$
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: rst-backticks
         exclude: CHANGELOG\.rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,15 @@ repos:
     -   id: pyupgrade
         args: [--py36-plus]
 
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+      - id: black
+        args: ["--line-length=99"]
+
   # PyDocStyle
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.2.2
+    rev: 6.2.3
     hooks:
     - id: pydocstyle
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]


### PR DESCRIPTION
- Use pydocstyle instead of pep257 because it replaces it.
- Bump versions of hooks.
- Remove fixed python version from formatting action.
- Fix action warnings about Node.js 12 by updating them.
- Bump version of clang-format.

#131 corrects formatting - not sure why clang-format is passing here and not locally...