### PR TITLE
Update pid documentation to match src code

### DIFF
--- a/include/control_toolbox/pid.hpp
+++ b/include/control_toolbox/pid.hpp
@@ -60,7 +60,7 @@ namespace control_toolbox
   In particular, this class implements the standard
   pid equation:
 
-  \f$command  = -p_{term} - i_{term} - d_{term} \f$
+  \f$command  = p_{term} + i_{term} + d_{term} \f$
 
   where: <br>
   <UL TYPE="none">
@@ -72,7 +72,7 @@ namespace control_toolbox
 
   given:<br>
   <UL TYPE="none">
-  <LI>  \f$ p_{error}  = p_{state} - p_{target} \f$.
+  <LI>  \f$ p_{error}  = p_{target} - p_{state} \f$.
   </UL>
 
   \param p Proportional gain


### PR DESCRIPTION
I updated the documentation for the PID-control class in include/pid.hpp to match the actual behavior from src/pid.cpp.
In PID-control literature, the error is typically defined as 'error=target-state' and the computeCommand function is also used in this way (e.g. https://github.com/ros-controls/ros2_controllers/blob/a49a87da1df40851a80507d61931d12c969cb015/joint_trajectory_controller/src/joint_trajectory_controller.cpp#L245).

Related to #39 