### PR TITLE
Enable subclassing of PID implementation.

### DIFF
--- a/include/control_toolbox/pid.hpp
+++ b/include/control_toolbox/pid.hpp
@@ -279,7 +279,7 @@ public:
     return *this;
   }
 
-private:
+protected:
   // Store the PID gains in a realtime buffer to allow dynamic reconfigure to update it without
   // blocking the realtime update loop
   realtime_tools::RealtimeBuffer<Gains> gains_buffer_;


### PR DESCRIPTION
In some cases, internal values of PID have to be manipulated to work on hardware. This change enables to subclass the PID implementation and adjust internal states as needed.