### PR TITLE
[CI] Fix source build

### DIFF
--- a/.github/workflows/build-source_rollling.yml
+++ b/.github/workflows/build-source_rollling.yml
@@ -13,5 +13,5 @@ jobs:
     uses: ./.github/workflows/reusable-ros-tooling-source-build.yml
     with:
       ros_distro: rolling
-      ref: master
+      ref: ros2-master
       ros2_repo_branch: rolling

--- a/.github/workflows/humble-rhel-binary-build.yml
+++ b/.github/workflows/humble-rhel-binary-build.yml
@@ -21,7 +21,7 @@ jobs:
           path: src/control_toolbox
       - name: Install dependencies
         run: |
-          rosdep update
+          rosdep update --rosdistro $ROS_DISTRO
           rosdep install -iyr --from-path src/control_toolbox || true
       - name: Build and test
         run: |

--- a/.github/workflows/iron-rhel-binary-build.yml
+++ b/.github/workflows/iron-rhel-binary-build.yml
@@ -22,7 +22,7 @@ jobs:
           path: src/control_toolbox
       - name: Install dependencies
         run: |
-          rosdep update
+          rosdep update --rosdistro $ROS_DISTRO
           rosdep install -iyr --from-path src/control_toolbox || true
       - name: Build and test
         # source also underlay workspace with generate_parameter_library on rhel9

--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -22,7 +22,7 @@ jobs:
           path: src/control_toolbox
       - name: Install dependencies
         run: |
-          rosdep update
+          rosdep update --rosdistro $ROS_DISTRO
           rosdep install -iyr --from-path src/control_toolbox || true
       - name: Build and test
         # source also underlay workspace with generate_parameter_library on rhel9


### PR DESCRIPTION
There was the wrong branch in the rolling source build workflow, see [here](https://github.com/ros-controls/control_toolbox/actions/workflows/build-source_rollling.yml).

I also add `--rosdistro $ROS_DISTRO` to rosdep for the binary workflows 