### PR TITLE
Add custom rosdoc2 config

### DIFF
--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   check:
-    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-rosdoc2.yml@rosdoc2
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-rosdoc2.yml@master

--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -1,0 +1,16 @@
+name: rosdoc2
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - doc/**
+      - rosdoc2.yaml
+      - package.xml
+
+
+jobs:
+  check:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-rosdoc2.yml@rosdoc2

--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -3,8 +3,6 @@ name: rosdoc2
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - master
     paths:
       - doc/**
       - rosdoc2.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,7 @@ repos:
         description: Check if copyright notice is available in all files.
         entry: ament_copyright
         language: system
+        exclude: doc/conf.py
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ control_toolbox
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![codecov](https://codecov.io/gh/ros-controls/control_toolbox/graph/badge.svg?token=0o4dFzADHj)](https://codecov.io/gh/ros-controls/control_toolbox)
 
+This package contains several C++ classes useful in writing controllers.
+
 See the documentation of [ros2_control](http://control.ros.org) and release infos on [index.ros.org](http://index.ros.org/p/control_toolbox).
 
 ## Build status

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,5 @@
+# Configuration file for the Sphinx documentation builder.
+# settings will be overridden by rosdoc2, so we add here only custom settings
+
+copyright = "2024, ros2_control development team"
+html_logo = "https://control.ros.org/master/_static/logo_ros-controls.png"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,23 @@
+Welcome to the documentation for control_toolbox
+================================================
+
+This package contains several C++ classes useful in writing controllers.
+
+For more information of the ros2_control framework see `control.ros.org <https://control.ros.org/>`__.
+
+
+API documentation
+------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   C++ API <generated/index>
+   Service Definitions <generated/service_definitions>
+
+
+Indices and Search
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="website">http://ros.org/wiki/control_toolbox</url>
+  <url type="website">https://control.ros.org</url>
   <url type="bugtracker">https://github.com/ros-controls/control_toolbox/issues</url>
   <url type="repository">https://github.com/ros-controls/control_toolbox/</url>
 


### PR DESCRIPTION
rosdoc2 will be used by the build farm to publish API docs on http://docs.ros.org/en/rolling/p/control_toolbox/

- Add custom landing page for rosdoc2: logo, links to control.ros.org
- Copy over information from https://wiki.ros.org/control_toolbox
- add rosdoc2 workflow, but only if the relevant files changed

![image](https://github.com/ros-controls/control_toolbox/assets/3367244/154904ed-75c7-4369-97cc-0c5e066078c4)
