### PR TITLE
Move speed limiter from ros2_control repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,9 @@ if(BUILD_TESTING)
   ament_add_gmock(pid_tests test/pid_tests.cpp)
   target_link_libraries(pid_tests control_toolbox)
 
+  ament_add_gmock(speed_limiter_tests test/speed_limiter.cpp)
+  target_link_libraries(speed_limiter_tests control_toolbox)
+
   ament_add_gtest(pid_parameters_tests test/pid_parameters_tests.cpp)
   target_link_libraries(pid_parameters_tests control_toolbox)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(control_toolbox SHARED
   src/pid.cpp
   src/sine_sweep.cpp
   src/sinusoid.cpp
+  src/speed_limiter.cpp
 )
 target_compile_features(control_toolbox PUBLIC cxx_std_17)
 target_include_directories(control_toolbox PUBLIC

--- a/include/control_toolbox/speed_limiter.hpp
+++ b/include/control_toolbox/speed_limiter.hpp
@@ -1,0 +1,105 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#ifndef CONTROL_TOOLBOX__SPEED_LIMITER_HPP_
+#define CONTROL_TOOLBOX__SPEED_LIMITER_HPP_
+
+#include <cmath>
+
+namespace control_toolbox
+{
+class SpeedLimiter
+{
+public:
+  /**
+   * \brief Constructor
+   * \param [in] has_velocity_limits     if true, applies velocity limits
+   * \param [in] has_acceleration_limits if true, applies acceleration limits
+   * \param [in] has_jerk_limits         if true, applies jerk limits
+   * \param [in] min_velocity Minimum velocity [m/s], usually <= 0
+   * \param [in] max_velocity Maximum velocity [m/s], usually >= 0
+   * \param [in] min_acceleration Minimum acceleration [m/s^2], usually <= 0
+   * \param [in] max_acceleration Maximum acceleration [m/s^2], usually >= 0
+   * \param [in] min_jerk Minimum jerk [m/s^3], usually <= 0
+   * \param [in] max_jerk Maximum jerk [m/s^3], usually >= 0
+   */
+  SpeedLimiter(
+    bool has_velocity_limits = false, bool has_acceleration_limits = false,
+    bool has_jerk_limits = false, double min_velocity = NAN, double max_velocity = NAN,
+    double min_acceleration = NAN, double max_acceleration = NAN, double min_jerk = NAN,
+    double max_jerk = NAN);
+
+  /**
+   * \brief Limit the velocity and acceleration
+   * \param [in, out] v  Velocity [m/s]
+   * \param [in]      v0 Previous velocity to v  [m/s]
+   * \param [in]      v1 Previous velocity to v0 [m/s]
+   * \param [in]      dt Time step [s]
+   * \return Limiting factor (1.0 if none)
+   */
+  double limit(double & v, double v0, double v1, double dt);
+
+  /**
+   * \brief Limit the velocity
+   * \param [in, out] v Velocity [m/s]
+   * \return Limiting factor (1.0 if none)
+   */
+  double limit_velocity(double & v);
+
+  /**
+   * \brief Limit the acceleration
+   * \param [in, out] v  Velocity [m/s]
+   * \param [in]      v0 Previous velocity [m/s]
+   * \param [in]      dt Time step [s]
+   * \return Limiting factor (1.0 if none)
+   */
+  double limit_acceleration(double & v, double v0, double dt);
+
+  /**
+   * \brief Limit the jerk
+   * \param [in, out] v  Velocity [m/s]
+   * \param [in]      v0 Previous velocity to v  [m/s]
+   * \param [in]      v1 Previous velocity to v0 [m/s]
+   * \param [in]      dt Time step [s]
+   * \return Limiting factor (1.0 if none)
+   * \see http://en.wikipedia.org/wiki/Jerk_%28physics%29#Motion_control
+   */
+  double limit_jerk(double & v, double v0, double v1, double dt);
+
+private:
+  // Enable/Disable velocity/acceleration/jerk limits:
+  bool has_velocity_limits_;
+  bool has_acceleration_limits_;
+  bool has_jerk_limits_;
+
+  // Velocity limits:
+  double min_velocity_;
+  double max_velocity_;
+
+  // Acceleration limits:
+  double min_acceleration_;
+  double max_acceleration_;
+
+  // Jerk limits:
+  double min_jerk_;
+  double max_jerk_;
+};
+
+}  // namespace control_toolbox
+
+#endif  // CONTROL_TOOLBOX__SPEED_LIMITER_HPP_

--- a/src/speed_limiter.cpp
+++ b/src/speed_limiter.cpp
@@ -1,0 +1,139 @@
+// Copyright 2020 PAL Robotics S.L.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Author: Enrique Fernández
+ */
+
+#include <algorithm>
+#include <stdexcept>
+
+#include "control_toolbox/speed_limiter.hpp"
+
+namespace control_toolbox
+{
+SpeedLimiter::SpeedLimiter(
+  bool has_velocity_limits, bool has_acceleration_limits, bool has_jerk_limits, double min_velocity,
+  double max_velocity, double min_acceleration, double max_acceleration, double min_jerk,
+  double max_jerk)
+: has_velocity_limits_(has_velocity_limits),
+  has_acceleration_limits_(has_acceleration_limits),
+  has_jerk_limits_(has_jerk_limits),
+  min_velocity_(min_velocity),
+  max_velocity_(max_velocity),
+  min_acceleration_(min_acceleration),
+  max_acceleration_(max_acceleration),
+  min_jerk_(min_jerk),
+  max_jerk_(max_jerk)
+{
+  // Check if limits are valid, max must be specified, min defaults to -max if unspecified
+  if (has_velocity_limits_)
+  {
+    if (std::isnan(max_velocity_))
+    {
+      throw std::runtime_error("Cannot apply velocity limits if max_velocity is not specified");
+    }
+    if (std::isnan(min_velocity_))
+    {
+      min_velocity_ = -max_velocity_;
+    }
+  }
+  if (has_acceleration_limits_)
+  {
+    if (std::isnan(max_acceleration_))
+    {
+      throw std::runtime_error(
+        "Cannot apply acceleration limits if max_acceleration is not specified");
+    }
+    if (std::isnan(min_acceleration_))
+    {
+      min_acceleration_ = -max_acceleration_;
+    }
+  }
+  if (has_jerk_limits_)
+  {
+    if (std::isnan(max_jerk_))
+    {
+      throw std::runtime_error("Cannot apply jerk limits if max_jerk is not specified");
+    }
+    if (std::isnan(min_jerk_))
+    {
+      min_jerk_ = -max_jerk_;
+    }
+  }
+}
+
+double SpeedLimiter::limit(double & v, double v0, double v1, double dt)
+{
+  const double tmp = v;
+
+  limit_jerk(v, v0, v1, dt);
+  limit_acceleration(v, v0, dt);
+  limit_velocity(v);
+
+  return tmp != 0.0 ? v / tmp : 1.0;
+}
+
+double SpeedLimiter::limit_velocity(double & v)
+{
+  const double tmp = v;
+
+  if (has_velocity_limits_)
+  {
+    v = std::clamp(v, min_velocity_, max_velocity_);
+  }
+
+  return tmp != 0.0 ? v / tmp : 1.0;
+}
+
+double SpeedLimiter::limit_acceleration(double & v, double v0, double dt)
+{
+  const double tmp = v;
+
+  if (has_acceleration_limits_)
+  {
+    const double dv_min = min_acceleration_ * dt;
+    const double dv_max = max_acceleration_ * dt;
+
+    const double dv = std::clamp(v - v0, dv_min, dv_max);
+
+    v = v0 + dv;
+  }
+
+  return tmp != 0.0 ? v / tmp : 1.0;
+}
+
+double SpeedLimiter::limit_jerk(double & v, double v0, double v1, double dt)
+{
+  const double tmp = v;
+
+  if (has_jerk_limits_)
+  {
+    const double dv = v - v0;
+    const double dv0 = v0 - v1;
+
+    const double dt2 = 2. * dt * dt;
+
+    const double da_min = min_jerk_ * dt2;
+    const double da_max = max_jerk_ * dt2;
+
+    const double da = std::clamp(dv - dv0, da_min, da_max);
+
+    v = v0 + dv0 + da;
+  }
+
+  return tmp != 0.0 ? v / tmp : 1.0;
+}
+
+}  // namespace control_toolbox

--- a/test/speed_limiter.cpp
+++ b/test/speed_limiter.cpp
@@ -1,0 +1,115 @@
+// Copyright 2024 AIT - Austrian Institute of Technology GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include "control_toolbox/speed_limiter.hpp"
+
+
+TEST(SpeedLimiterTest, testLinearVelocityLimits)
+{
+  control_toolbox::SpeedLimiter limiter(true, true, true, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
+
+  {
+    double v = 10.0;
+    double limiting_factor = limiter.limit_velocity(v);
+    // check if the robot speed is now 1.0 m.s-1, the limit
+    EXPECT_DOUBLE_EQ(v, 1.0);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.1);
+    v = -10.0;
+    limiting_factor = limiter.limit_velocity(v);
+    // check if the robot speed is now -0.5 m.s-1, the limit
+    EXPECT_DOUBLE_EQ(v, -0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+  }
+
+  {
+    double v = 10.0;
+    double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // acceleration is now limiting, not velocity
+    // check if the robot speed is now 0.5 m.s-1, which is 1.0m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+    v = -10.0;
+    limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // acceleration is now limiting, not velocity
+    // check if the robot speed is now -0.25 m.s-1, which is 0.5m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
+  }
+}
+
+TEST(SpeedLimiterTest, testLinearAccelerationLimits)
+{
+  control_toolbox::SpeedLimiter limiter(true, true, true, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
+
+  {
+    double v = 10.0;
+    double limiting_factor = limiter.limit_acceleration(v, 0.0, 0.5);
+    // check if the robot speed is now 0.5 m.s-1, which is 1.0m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+
+    v = -10.0;
+    limiting_factor = limiter.limit_acceleration(v, 0.0, 0.5);
+    // check if the robot speed is now -0.25 m.s-1, which is -0.5m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
+  }
+
+  {
+    double v = 10.0;
+    double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // check if the robot speed is now 0.5 m.s-1, which is 1.0m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+
+    v = -10.0;
+    limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // check if the robot speed is now -0.25 m.s-1, which is -0.5m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
+  }
+}
+
+TEST(SpeedLimiterTest, testLinearJerkLimits)
+{
+  control_toolbox::SpeedLimiter limiter(true, true, true, -0.5, 1.0, -0.5, 1.0, -1.0, 1.0);
+
+  {
+    double v = 10.0;
+    double limiting_factor = limiter.limit_jerk(v, 0.0, 0.0, 0.5);
+    // check if the robot speed is now 0.5m.s-1 = 1.0m.s-3 * 2 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+    v = -10.0;
+    limiting_factor = limiter.limit_jerk(v, 0.0, 0.0, 0.5);
+    // check if the robot speed is now -0.5m.s-1 = -1.0m.s-3 * 2 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+  }
+  {
+    double v = 10.0;
+    double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // check if the robot speed is now 0.5m.s-1 = 1.0m.s-3 * 2 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+    v = -10.0;
+    limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // acceleration is limiting, not jerk
+    // check if the robot speed is now -0.25 m.s-1, which is -0.5m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
+  }
+}

--- a/test/speed_limiter.cpp
+++ b/test/speed_limiter.cpp
@@ -17,7 +17,22 @@
 #include "control_toolbox/speed_limiter.hpp"
 
 
-TEST(SpeedLimiterTest, testLinearVelocityLimits)
+TEST(SpeedLimiterTest, testNoLimits)
+{
+    control_toolbox::SpeedLimiter limiter;
+    double v = 10.0;
+    double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // check if the velocity is not limited
+    EXPECT_DOUBLE_EQ(v, 10.0);
+    EXPECT_DOUBLE_EQ(limiting_factor, 1.0);
+    v = -10.0;
+    limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // check if the velocity is not limited
+    EXPECT_DOUBLE_EQ(v, -10.0);
+    EXPECT_DOUBLE_EQ(limiting_factor, 1.0);
+}
+
+TEST(SpeedLimiterTest, testVelocityLimits)
 {
   control_toolbox::SpeedLimiter limiter(true, true, true, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
 
@@ -44,13 +59,74 @@ TEST(SpeedLimiterTest, testLinearVelocityLimits)
     v = -10.0;
     limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
     // acceleration is now limiting, not velocity
-    // check if the robot speed is now -0.25 m.s-1, which is 0.5m.s-2 * 0.5s
+    // check if the robot speed is now 0.5 m.s-1, which is 1.0m.s-2 * 0.5s
     EXPECT_DOUBLE_EQ(v, -0.25);
     EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
   }
 }
 
-TEST(SpeedLimiterTest, testLinearAccelerationLimits)
+TEST(SpeedLimiterTest, testVelocityNoLimits)
+{
+  {
+    control_toolbox::SpeedLimiter limiter(false, true, true, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
+    double v = 10.0;
+    double limiting_factor = limiter.limit_velocity(v);
+    // check if the velocity is not limited
+    EXPECT_DOUBLE_EQ(v, 10.0);
+    EXPECT_DOUBLE_EQ(limiting_factor, 1.0);
+    v = -10.0;
+    limiting_factor = limiter.limit_velocity(v);
+    // check if the velocity is not limited
+    EXPECT_DOUBLE_EQ(v, -10.0);
+    EXPECT_DOUBLE_EQ(limiting_factor, 1.0);
+  }
+
+  {
+    control_toolbox::SpeedLimiter limiter(false, true, true, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
+    double v = 10.0;
+    double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // acceleration is now limiting, not velocity
+    // check if the robot speed is now 0.5 m.s-1, which is 1.0m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+    v = -10.0;
+    limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // acceleration is now limiting, not velocity
+    // check if the robot speed is now 0.5 m.s-1, which is 1.0m.s-2 * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
+  }
+
+  {
+    control_toolbox::SpeedLimiter limiter(false, false, true, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
+    double v = 10.0;
+    double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // jerk is now limiting, not velocity
+    EXPECT_DOUBLE_EQ(v, 2.5);
+    EXPECT_DOUBLE_EQ(limiting_factor, 2.5/10.0);
+    v = -10.0;
+    limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // jerk is now limiting, not velocity
+    EXPECT_DOUBLE_EQ(v, -0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
+  }
+
+  {
+    control_toolbox::SpeedLimiter limiter(false, false, false, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
+    double v = 10.0;
+    double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // check if the velocity is not limited
+    EXPECT_DOUBLE_EQ(v, 10.0);
+    EXPECT_DOUBLE_EQ(limiting_factor, 1.0);
+    v = -10.0;
+    limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
+    // check if the velocity is not limited
+    EXPECT_DOUBLE_EQ(v, -10.0);
+    EXPECT_DOUBLE_EQ(limiting_factor, 1.0);
+  }
+}
+
+TEST(SpeedLimiterTest, testAccelerationLimits)
 {
   control_toolbox::SpeedLimiter limiter(true, true, true, -0.5, 1.0, -0.5, 1.0, -0.5, 5.0);
 
@@ -83,7 +159,7 @@ TEST(SpeedLimiterTest, testLinearAccelerationLimits)
   }
 }
 
-TEST(SpeedLimiterTest, testLinearJerkLimits)
+TEST(SpeedLimiterTest, testJerkLimits)
 {
   control_toolbox::SpeedLimiter limiter(true, true, true, -0.5, 1.0, -0.5, 1.0, -1.0, 1.0);
 


### PR DESCRIPTION
I thought it would be beneficial to reuse the SpeedLimiter of the diff_drive controller in the steering_controllers_library.

The SpeedLimiter might be useful for other controllers as well, so I suggest to add it to the control_toolbox repo.
But how can we deal with the change of the license from Apache 2 to BSD-3-Clause in this repo? Other suggestions?

Additionally, I added some tests because there were none.