### PR TITLE
Add semi-binary build

### DIFF
--- a/.github/workflows/build-semi-binary.yml
+++ b/.github/workflows/build-semi-binary.yml
@@ -1,0 +1,27 @@
+# This config uses industrial_ci (https://github.com/ros-industrial/industrial_ci.git).
+# For troubleshooting, see readme (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
+
+name: Semi-Binary Build
+on:
+  pull_request:
+  push:
+    branches:
+      - ros2-master
+  schedule:
+    # Run every day to detect flakiness and broken dependencies
+    - cron: '28 6 * * *'
+
+
+jobs:
+  semi-binary:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [rolling, jazzy, iron, humble]
+        ROS_REPO: [main, testing]
+    with:
+      ros_distro: ${{ matrix.ROS_DISTRO }}
+      ros_repo: ${{ matrix.ROS_REPO }}
+      upstream_workspace: control_toolbox.${{ matrix.ROS_DISTRO }}.repos
+      ref_for_scheduled_build: ros2-master

--- a/.github/workflows/build-semi-binary.yml
+++ b/.github/workflows/build-semi-binary.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         ROS_DISTRO: [rolling, jazzy, iron, humble]
-        ROS_REPO: [main, testing]
+        ROS_REPO: [testing]
     with:
       ros_distro: ${{ matrix.ROS_DISTRO }}
       ros_repo: ${{ matrix.ROS_REPO }}


### PR DESCRIPTION
Now we have the situation that binary testing builds fail, but don't see if this repo with realtime_tools compiled from source would work.