### PR TITLE
Fix jerk limiter in rate_limiter

### DIFF
--- a/include/control_toolbox/rate_limiter.hpp
+++ b/include/control_toolbox/rate_limiter.hpp
@@ -297,7 +297,7 @@ T RateLimiter<T>::limit_second_derivative(T & v, T v0, T v1, T dt)
     const T dv = v - v0;
     const T dv0 = v0 - v1;
 
-    const T dt2 = static_cast<T>(2.0) * dt * dt;
+    const T dt2 = dt * dt;
 
     const T da_min = min_second_derivative_ * dt2;
     const T da_max = max_second_derivative_ * dt2;

--- a/include/control_toolbox/rate_limiter.hpp
+++ b/include/control_toolbox/rate_limiter.hpp
@@ -236,9 +236,9 @@ T RateLimiter<T>::limit(T & v, T v0, T v1, T dt)
 {
   const T tmp = v;
 
-  limit_second_derivative(v, v0, v1, dt);
-  limit_first_derivative(v, v0, dt);
   limit_value(v);
+  limit_first_derivative(v, v0, dt);
+  limit_second_derivative(v, v0, v1, dt);
 
   return tmp != static_cast<T>(0.0) ? v / tmp : static_cast<T>(1.0);
 }

--- a/include/control_toolbox/rate_limiter.hpp
+++ b/include/control_toolbox/rate_limiter.hpp
@@ -300,7 +300,7 @@ T RateLimiter<T>::limit_second_derivative(T & v, T v0, T v1, T dt)
     // Only limit jerk when accelerating or reverse_accelerating
     // Note: this prevents oscillating closed-loop behavior, see discussion
     // details in https://github.com/ros-controls/control_toolbox/issues/240.
-    if ((dv - dv0) * (v - v0) >= 0)
+    if ((dv - dv0) * (v - v0) > 0)
     {
       const T dt2 = dt * dt;
 

--- a/include/control_toolbox/rate_limiter.hpp
+++ b/include/control_toolbox/rate_limiter.hpp
@@ -47,6 +47,13 @@ public:
    * If max_* values are NAN, the respective limit is deactivated
    * If min_* values are NAN (unspecified), defaults to -max
    * If min_first_derivative_pos/max_first_derivative_neg values are NAN, symmetric limits are used
+   *
+   * Disclaimer about the jerk limits:
+   *    The jerk limit is only applied when accelerating or reverse_accelerating (i.e., "sign(jerk * accel) > 0").
+   *    This condition prevents oscillating closed-loop behavior, see discussion details in
+   *    https://github.com/ros-controls/control_toolbox/issues/240.
+   *    if you use this feature, you should perform a test to check that the behavior is really as you expect.
+   *
    */
   RateLimiter(
     T min_value = std::numeric_limits<double>::quiet_NaN(),
@@ -92,6 +99,8 @@ public:
    * \param [in]      dt Time step [s]
    * \return Limiting factor (1.0 if none)
    * \see http://en.wikipedia.org/wiki/jerk_%28physics%29#Motion_control
+   * \note
+   * The jerk limit is only applied when accelerating or reverse_accelerating (i.e., "sign(jerk * accel) > 0").
    */
   T limit_second_derivative(T & v, T v0, T v1, T dt);
 

--- a/include/control_toolbox/rate_limiter.hpp
+++ b/include/control_toolbox/rate_limiter.hpp
@@ -236,9 +236,9 @@ T RateLimiter<T>::limit(T & v, T v0, T v1, T dt)
 {
   const T tmp = v;
 
-  limit_value(v);
-  limit_first_derivative(v, v0, dt);
   limit_second_derivative(v, v0, v1, dt);
+  limit_first_derivative(v, v0, dt);
+  limit_value(v);
 
   return tmp != static_cast<T>(0.0) ? v / tmp : static_cast<T>(1.0);
 }

--- a/test/rate_limiter.cpp
+++ b/test/rate_limiter.cpp
@@ -181,7 +181,7 @@ TEST(RateLimiterTest, testValueNoLimits)
       std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
       -0.5, 1.0,
       std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
-      -0.5, 5.0
+      -2.0, 2.0
     );
     double v = 10.0;
     double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
@@ -207,13 +207,15 @@ TEST(RateLimiterTest, testValueNoLimits)
     double v = 10.0;
     double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
     // second_derivative is now limiting, not value
-    EXPECT_DOUBLE_EQ(v, 2.5);
-    EXPECT_DOUBLE_EQ(limiting_factor, 2.5/10.0);
+    // check if the robot speed is now 1.25 m.s-1, which is 5.0 m.s-3 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, 1.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 1.25/10.0);
     v = -10.0;
     limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
     // second_derivative is now limiting, not value
-    EXPECT_DOUBLE_EQ(v, -0.25);
-    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
+    // check if the robot speed is now -0.25 m.s-1, which is -0.5m.s-3 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.125);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.125/10.0);
   }
 
   {
@@ -323,21 +325,21 @@ TEST(RateLimiterTest, testSecondDerivativeLimits)
   {
     double v = 10.0;
     double limiting_factor = limiter.limit_second_derivative(v, 0.0, 0.0, 0.5);
-    // check if the robot speed is now 0.5m.s-1 = 1.0m.s-3 * 2 * 0.5s * 0.5s
-    EXPECT_DOUBLE_EQ(v, 0.5);
-    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+    // check if the robot speed is now 0.25m.s-1 = 1.0m.s-3 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
     v = -10.0;
     limiting_factor = limiter.limit_second_derivative(v, 0.0, 0.0, 0.5);
-    // check if the robot speed is now -0.5m.s-1 = -1.0m.s-3 * 2 * 0.5s * 0.5s
-    EXPECT_DOUBLE_EQ(v, -0.5);
-    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+    // check if the robot speed is now -0.25m.s-1 = -1.0m.s-3 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, -0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
   }
   {
     double v = 10.0;
     double limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
-    // check if the robot speed is now 0.5m.s-1 = 1.0m.s-3 * 2 * 0.5s * 0.5s
-    EXPECT_DOUBLE_EQ(v, 0.5);
-    EXPECT_DOUBLE_EQ(limiting_factor, 0.5/10.0);
+    // check if the robot speed is now 0.25m.s-1 = 1.0m.s-3 * 0.5s * 0.5s
+    EXPECT_DOUBLE_EQ(v, 0.25);
+    EXPECT_DOUBLE_EQ(limiting_factor, 0.25/10.0);
     v = -10.0;
     limiting_factor = limiter.limit(v, 0.0, 0.0, 0.5);
     // first_derivative is limiting, not second_derivative

--- a/test/rate_limiter.cpp
+++ b/test/rate_limiter.cpp
@@ -124,7 +124,7 @@ TEST(RateLimiterTest, testValueLimits)
     -0.5, 1.0,
     -0.5, 1.0,
     std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
-    -0.5, 5.0);
+    -2.0, 5.0);
 
   {
     double v = 10.0;
@@ -240,7 +240,7 @@ TEST(RateLimiterTest, testFirstDerivativeLimits)
   control_toolbox::RateLimiter limiter( -0.5, 1.0,
     -0.5, 1.0,
     std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(),
-    -0.5, 5.0
+    -2.0, 5.0
   );
 
   {


### PR DESCRIPTION
> [!NOTE]  
> This is a duplicate of a now closed PR against `ros-controls/ros2_controllers` (see [PR #1390](https://github.com/ros-controls/ros2_controllers/pull/1390)) that was initially intended for the `diff_drive_controller`.
> I was asked to move it here since the rate_limiter of the `diff_drive_controller` will be that of the `control_toolbox` (see [ros2_controllers,  PR #1315](https://github.com/ros-controls/ros2_controllers/pull/1315)).

Hi,

There seem to be an error in the jerk limiter ([speed_limiter.hpp #L290-L311](https://github.com/ros-controls/control_toolbox/blob/641c92954dbae1af0435cdeb105cbf5a1578d152/include/control_toolbox/rate_limiter.hpp#L290-L311)) caused by the (as far as I can tell) incorrect factor 2 in the computation of the velocity limit resulting from jerk limits.

The consequence is an overshoot of the configured jerk limit.
To illustrate the effect of this factor, let us set the linear jerk limit as $J_{max} = 20 \text{ m.s}^{-3}$.
Before the changes, the jerk reaches $40 \text{ m.s}^{-3}$ (i.e., 2 times the configured limit):
![diif_drive_current](https://github.com/user-attachments/assets/c065ea33-951b-4440-ab5a-aad85da707a6)


After, it is fine
![diif_drive_new](https://github.com/user-attachments/assets/ea92a9c2-9d30-4eb9-ba44-b69f17bc221c)

