### PR TITLE
Update include paths of GPL

### DIFF
--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: ros-industrial/industrial_ci@master
         env:
           ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
-          ROS_REPO: main
+          ROS_REPO: testing
           ABICHECK_URL: github:${{ github.repository }}#${{ github.base_ref }}
           NOT_TEST_BUILD: true

--- a/include/control_filters/exponential_filter.hpp
+++ b/include/control_filters/exponential_filter.hpp
@@ -22,7 +22,7 @@
 #include "filters/filter_base.hpp"
 
 #include "control_toolbox/filters.hpp"
-#include "exponential_filter_parameters.hpp"
+#include "control_toolbox/exponential_filter_parameters.hpp"
 
 namespace control_filters
 {

--- a/include/control_filters/low_pass_filter.hpp
+++ b/include/control_filters/low_pass_filter.hpp
@@ -22,7 +22,7 @@
 #include "geometry_msgs/msg/wrench_stamped.hpp"
 
 #include "control_toolbox/low_pass_filter.hpp"
-#include "low_pass_filter_parameters.hpp"
+#include "control_toolbox/low_pass_filter_parameters.hpp"
 
 namespace control_filters
 {

--- a/include/control_filters/rate_limiter.hpp
+++ b/include/control_filters/rate_limiter.hpp
@@ -24,7 +24,7 @@
 #include "filters/filter_base.hpp"
 
 #include "control_toolbox/rate_limiter.hpp"
-#include "rate_limiter_parameters.hpp"
+#include "control_toolbox/rate_limiter_parameters.hpp"
 
 namespace control_filters
 {


### PR DESCRIPTION
Needs [release 0.4.0](https://github.com/PickNikRobotics/generate_parameter_library/pull/232)
for reference, see https://github.com/PickNikRobotics/generate_parameter_library/pull/213