### PR TITLE
Replaced gMock instead of gTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,10 +139,10 @@ if(BUILD_TESTING)
   ament_add_gmock(rate_limiter_tests test/rate_limiter.cpp)
   target_link_libraries(rate_limiter_tests control_toolbox)
 
-  ament_add_gtest(pid_ros_parameters_tests test/pid_ros_parameters_tests.cpp)
+  ament_add_gmock(pid_ros_parameters_tests test/pid_ros_parameters_tests.cpp)
   target_link_libraries(pid_ros_parameters_tests control_toolbox)
 
-  ament_add_gtest(pid_ros_publisher_tests test/pid_ros_publisher_tests.cpp)
+  ament_add_gmock(pid_ros_publisher_tests test/pid_ros_publisher_tests.cpp)
   target_link_libraries(pid_ros_publisher_tests control_toolbox)
   ament_target_dependencies(pid_ros_publisher_tests rclcpp_lifecycle)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ pluginlib_export_plugin_description_file(filters control_filters.xml)
 ##########
 if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
-  find_package(ament_cmake_gtest REQUIRED)
   find_package(rclcpp_lifecycle REQUIRED)
 
   ament_add_gmock(pid_tests test/pid_tests.cpp)

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,6 @@
   <depend>realtime_tools</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>rclcpp_lifecycle</test_depend>
   <export>
     <build_type>ament_cmake</build_type>

--- a/test/control_filters/test_exponential_filter.cpp
+++ b/test/control_filters/test_exponential_filter.cpp
@@ -69,7 +69,7 @@ TEST_F(FilterTest, TestExponentialFilterComputation)
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/test/control_filters/test_load_exponential_filter.cpp
+++ b/test/control_filters/test_load_exponential_filter.cpp
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include <gmock/gmock.h>
 #include <memory>
 #include <string>
 
+#include "gmock/gmock.h"
 #include "rclcpp/utilities.hpp"
 #include "pluginlib/class_loader.hpp"
 

--- a/test/control_filters/test_load_exponential_filter.cpp
+++ b/test/control_filters/test_load_exponential_filter.cpp
@@ -15,8 +15,8 @@
 #include <string>
 
 #include "gmock/gmock.h"
-#include "rclcpp/utilities.hpp"
 #include "pluginlib/class_loader.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "control_filters/exponential_filter.hpp"
 

--- a/test/control_filters/test_load_low_pass_filter.cpp
+++ b/test/control_filters/test_load_low_pass_filter.cpp
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include <gmock/gmock.h>
 #include <memory>
 #include <string>
 
+#include "gmock/gmock.h"
 #include "geometry_msgs/msg/wrench_stamped.hpp"
 #include "rclcpp/utilities.hpp"
 #include "pluginlib/class_loader.hpp"

--- a/test/control_filters/test_load_low_pass_filter.cpp
+++ b/test/control_filters/test_load_low_pass_filter.cpp
@@ -14,10 +14,10 @@
 #include <memory>
 #include <string>
 
-#include "gmock/gmock.h"
 #include "geometry_msgs/msg/wrench_stamped.hpp"
-#include "rclcpp/utilities.hpp"
+#include "gmock/gmock.h"
 #include "pluginlib/class_loader.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "control_filters/low_pass_filter.hpp"
 

--- a/test/control_filters/test_load_rate_limiter.cpp
+++ b/test/control_filters/test_load_rate_limiter.cpp
@@ -11,11 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#include <gmock/gmock.h>
 #include <memory>
 #include <string>
 
+#include "gmock/gmock.h"
 #include "rclcpp/utilities.hpp"
 #include "pluginlib/class_loader.hpp"
 

--- a/test/control_filters/test_load_rate_limiter.cpp
+++ b/test/control_filters/test_load_rate_limiter.cpp
@@ -15,8 +15,8 @@
 #include <string>
 
 #include "gmock/gmock.h"
-#include "rclcpp/utilities.hpp"
 #include "pluginlib/class_loader.hpp"
+#include "rclcpp/utilities.hpp"
 
 #include "control_filters/rate_limiter.hpp"
 

--- a/test/control_filters/test_low_pass_filter.cpp
+++ b/test/control_filters/test_low_pass_filter.cpp
@@ -151,7 +151,7 @@ TEST_F(FilterTest, TestLowPassWrenchFilterComputation)
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/test/control_filters/test_rate_limiter.cpp
+++ b/test/control_filters/test_rate_limiter.cpp
@@ -100,7 +100,7 @@ TEST_F(FilterTest, TestRateLimiterCompute)
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/test/pid_ros_parameters_tests.cpp
+++ b/test/pid_ros_parameters_tests.cpp
@@ -11,11 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <gmock/gmock.h>
-
 #include <memory>
 
 #include "control_toolbox/pid_ros.hpp"
+
+#include "gmock/gmock.h"
 
 #include "rclcpp/executors.hpp"
 #include "rclcpp/node.hpp"

--- a/test/pid_ros_parameters_tests.cpp
+++ b/test/pid_ros_parameters_tests.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <memory>
 
@@ -402,7 +402,7 @@ TEST(PidParametersTest, MultiplePidInstances)
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/test/pid_ros_parameters_tests.cpp
+++ b/test/pid_ros_parameters_tests.cpp
@@ -16,7 +16,6 @@
 #include "control_toolbox/pid_ros.hpp"
 
 #include "gmock/gmock.h"
-
 #include "rclcpp/executors.hpp"
 #include "rclcpp/node.hpp"
 #include "rclcpp/parameter.hpp"

--- a/test/pid_ros_publisher_tests.cpp
+++ b/test/pid_ros_publisher_tests.cpp
@@ -19,7 +19,7 @@
 
 #include "control_toolbox/pid_ros.hpp"
 
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include "rclcpp/duration.hpp"
 #include "rclcpp/executors.hpp"
@@ -103,7 +103,7 @@ TEST(PidPublisherTest, PublishTestLifecycle)
 
 int main(int argc, char ** argv)
 {
-  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
   rclcpp::init(argc, argv);
   int result = RUN_ALL_TESTS();
   rclcpp::shutdown();

--- a/test/pid_tests.cpp
+++ b/test/pid_tests.cpp
@@ -35,7 +35,7 @@
 
 #include "control_toolbox/pid.hpp"
 
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 using control_toolbox::Pid;
 using namespace std::chrono_literals;
@@ -489,6 +489,6 @@ TEST(CommandTest, timeArgumentTest)
 
 int main(int argc, char ** argv)
 {
-  testing::InitGoogleTest(&argc, argv);
+  testing::InitGoogleMock(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR resolves [this issue](https://github.com/ros-controls/control_toolbox/issues/256).