### PR TITLE
Update upstream/downstream repository branches

### DIFF
--- a/control_toolbox.humble.repos
+++ b/control_toolbox.humble.repos
@@ -6,4 +6,4 @@ repositories:
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools
-    version: master
+    version: humble

--- a/control_toolbox.jazzy.repos
+++ b/control_toolbox.jazzy.repos
@@ -2,8 +2,8 @@ repositories:
   control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    version: master
+    version: jazzy
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools
-    version: master
+    version: jazzy

--- a/ros_controls.jazzy.repos
+++ b/ros_controls.jazzy.repos
@@ -1,15 +1,7 @@
 repositories:
-  ros-controls/control_msgs:
-    type: git
-    url: https://github.com/ros-controls/control_msgs.git
-    version: master
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
-    version: master
-  ros-controls/realtime_tools:
-    type: git
-    url: https://github.com/ros-controls/realtime_tools.git
     version: jazzy
   ros-controls/ros2_control:
     type: git

--- a/ros_controls.rolling.repos
+++ b/ros_controls.rolling.repos
@@ -1,15 +1,7 @@
 repositories:
-  ros-controls/control_msgs:
-    type: git
-    url: https://github.com/ros-controls/control_msgs.git
-    version: master
   ros-controls/kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
-    version: master
-  ros-controls/realtime_tools:
-    type: git
-    url: https://github.com/ros-controls/realtime_tools.git
     version: master
   ros-controls/ros2_control:
     type: git


### PR DESCRIPTION
- Upstream, we branched already for jazzy
- Downstream, we don't need to repeat the repos from the control_toolbox repos file since #301