### PR TITLE
Don't return cmd if called with dt=0 or garbage

### DIFF
--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <utility>
 
@@ -143,7 +144,7 @@ double Pid::compute_command(double error, const double & dt_s)
 {
   if (dt_s < 0.0) {
     throw std::invalid_argument("Pid is called with negative dt");
-  } else if (dt_s <= 0.0) {
+  } else if (dt_s <=  std::numeric_limits<float>::epsilon()) {
     // don't update anything
     return cmd_;
   }
@@ -189,7 +190,7 @@ double Pid::compute_command(double error, double error_dot, const double & dt_s)
 {
   if (dt_s < 0.0) {
     throw std::invalid_argument("Pid is called with negative dt");
-  } else if (dt_s <= 0.0) {
+  } else if (dt_s <=  std::numeric_limits<float>::epsilon()) {
     // don't update anything
     return cmd_;
   }

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -141,8 +141,16 @@ void Pid::set_gains(const Gains & gains)
 
 double Pid::compute_command(double error, const double & dt_s)
 {
-  if (dt_s <= 0.0 || !std::isfinite(error)) {
-    return 0.0;
+  if (dt_s < 0.0) {
+    throw std::invalid_argument("Pid is called with negative dt");
+  } else if (dt_s <= 0.0) {
+    // don't update anything
+    return cmd_;
+  }
+
+  // reset controller
+  if (!std::isfinite(error)) {
+    return cmd_ = i_term_ = 0.0;
   }
 
   // Calculate the derivative error
@@ -179,8 +187,10 @@ double Pid::compute_command(
 
 double Pid::compute_command(double error, double error_dot, const double & dt_s)
 {
-  // don't update anything
-  if (dt_s <= 0.0) {
+  if (dt_s < 0.0) {
+    throw std::invalid_argument("Pid is called with negative dt");
+  } else if (dt_s <= 0.0) {
+    // don't update anything
     return cmd_;
   }
 
@@ -191,6 +201,7 @@ double Pid::compute_command(double error, double error_dot, const double & dt_s)
   p_error_ = error;  // this is error = target - state
   d_error_ = error_dot;
 
+  // reset controller
   if (!std::isfinite(error) || !std::isfinite(error_dot)) {
     return cmd_ = i_term_ = 0.0;
   }

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -179,6 +179,11 @@ double Pid::compute_command(
 
 double Pid::compute_command(double error, double error_dot, const double & dt_s)
 {
+  // don't update anything
+  if (dt_s <= 0.0) {
+    return cmd_;
+  }
+
   // Get the gain parameters from the realtime buffer
   Gains gains = *gains_buffer_.readFromRT();
 
@@ -186,9 +191,8 @@ double Pid::compute_command(double error, double error_dot, const double & dt_s)
   p_error_ = error;  // this is error = target - state
   d_error_ = error_dot;
 
-  if (
-    dt_s <= 0.0 || !std::isfinite(error) || !std::isfinite(error_dot)) {
-    return 0.0;
+  if (!std::isfinite(error) || !std::isfinite(error_dot)) {
+    return cmd_ = i_term_ = 0.0;
   }
 
   // Calculate proportional contribution to command

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -149,9 +149,10 @@ double Pid::compute_command(double error, const double & dt_s)
     return cmd_;
   }
 
-  // reset controller
+  // don't reset controller but return NaN
   if (!std::isfinite(error)) {
-    return cmd_ = i_term_ = 0.0;
+    std::cout << "Received a non-finite error value\n";
+    return cmd_ = std::numeric_limits<float>::quiet_NaN();
   }
 
   // Calculate the derivative error
@@ -202,9 +203,10 @@ double Pid::compute_command(double error, double error_dot, const double & dt_s)
   p_error_ = error;  // this is error = target - state
   d_error_ = error_dot;
 
-  // reset controller
+  // don't reset controller but return NaN
   if (!std::isfinite(error) || !std::isfinite(error_dot)) {
-    return cmd_ = i_term_ = 0.0;
+    std::cout << "Received a non-finite error/error_dot value\n";
+    return cmd_ = std::numeric_limits<float>::quiet_NaN();
   }
 
   // Calculate proportional contribution to command

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -142,11 +142,11 @@ void Pid::set_gains(const Gains & gains)
 
 double Pid::compute_command(double error, const double & dt_s)
 {
-  if (dt_s < 0.0) {
-    throw std::invalid_argument("Pid is called with negative dt");
-  } else if (dt_s <=  std::numeric_limits<float>::epsilon()) {
+  if (std::abs(dt_s) <=  std::numeric_limits<float>::epsilon()) {
     // don't update anything
     return cmd_;
+  } else if (dt_s < 0.0) {
+    throw std::invalid_argument("Pid is called with negative dt");
   }
 
   // don't reset controller but return NaN
@@ -189,13 +189,12 @@ double Pid::compute_command(
 
 double Pid::compute_command(double error, double error_dot, const double & dt_s)
 {
-  if (dt_s < 0.0) {
-    throw std::invalid_argument("Pid is called with negative dt");
-  } else if (dt_s <=  std::numeric_limits<float>::epsilon()) {
+  if (std::abs(dt_s) <=  std::numeric_limits<float>::epsilon()) {
     // don't update anything
     return cmd_;
+  } else if (dt_s < 0.0) {
+    throw std::invalid_argument("Pid is called with negative dt");
   }
-
   // Get the gain parameters from the realtime buffer
   Gains gains = *gains_buffer_.readFromRT();
 

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -495,19 +495,19 @@ TEST(CommandTest, timeArgumentTest)
   EXPECT_EQ(ie1, ie2);
   // should throw if called with negative dt
   EXPECT_THROW(cmd1 = pid1.compute_command(-0.5, 0.0, -1.0), std::invalid_argument);
-  // call with nan, should reset command and integral error
+  // call with nan, should return NaN but not reset internal states
   cmd1 = pid1.compute_command(std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0);
   cmd3 = pid1.get_current_cmd();
-  pid1.get_current_pid_errors(pe, ie1, de);
-  EXPECT_EQ(0.0, cmd1);
-  EXPECT_EQ(0.0, ie1);
-  EXPECT_EQ(0.0, cmd3);
+  EXPECT_FALSE(std::isfinite(cmd1));
+  EXPECT_FALSE(std::isfinite(cmd3));
+  pid1.get_current_pid_errors(pe, ie2, de);
+  EXPECT_EQ(ie1, ie2);
   cmd2 = pid2.compute_command(-0.5, std::numeric_limits<double>::quiet_NaN(), 1.0);
   cmd4 = pid2.get_current_cmd();
+  EXPECT_FALSE(std::isfinite(cmd2));
+  EXPECT_FALSE(std::isfinite(cmd4));
   pid1.get_current_pid_errors(pe, ie2, de);
-  EXPECT_EQ(0.0, cmd2);
-  EXPECT_EQ(0.0, cmd4);
-  EXPECT_EQ(0.0, ie2);
+  EXPECT_EQ(ie1, ie2);
 }
 
 int main(int argc, char ** argv)

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -493,6 +493,8 @@ TEST(CommandTest, timeArgumentTest)
   pid1.get_current_pid_errors(pe, ie2, de);
   EXPECT_EQ(-2.0, cmd1);
   EXPECT_EQ(ie1, ie2);
+  // should throw if called with negative dt
+  EXPECT_THROW(cmd1 = pid1.compute_command(-0.5, 0.0, -1.0), std::invalid_argument);
   // call with nan, should reset command and integral error
   cmd1 = pid1.compute_command(std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0);
   cmd3 = pid1.get_current_cmd();

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -485,6 +485,27 @@ TEST(CommandTest, timeArgumentTest)
   EXPECT_EQ(cmd1, cmd2);
   EXPECT_EQ(cmd1, cmd3);
   EXPECT_EQ(cmd1, cmd4);
+
+  // call with dt=0, nothing should change
+  double pe, ie1, de, ie2;
+  pid1.get_current_pid_errors(pe, ie1, de);
+  cmd1 = pid1.compute_command(-0.5, 0.0, 0.0);
+  pid1.get_current_pid_errors(pe, ie2, de);
+  EXPECT_EQ(-2.0, cmd1);
+  EXPECT_EQ(ie1, ie2);
+  // call with nan, should reset command and integral error
+  cmd1 = pid1.compute_command(std::numeric_limits<double>::quiet_NaN(), 0.0, 1.0);
+  cmd3 = pid1.get_current_cmd();
+  pid1.get_current_pid_errors(pe, ie1, de);
+  EXPECT_EQ(0.0, cmd1);
+  EXPECT_EQ(0.0, ie1);
+  EXPECT_EQ(0.0, cmd3);
+  cmd2 = pid2.compute_command(-0.5, std::numeric_limits<double>::quiet_NaN(), 1.0);
+  cmd4 = pid2.get_current_cmd();
+  pid1.get_current_pid_errors(pe, ie2, de);
+  EXPECT_EQ(0.0, cmd2);
+  EXPECT_EQ(0.0, cmd4);
+  EXPECT_EQ(0.0, ie2);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Fixes #31 

- return the same command if update is called with dt=0
- return NaN if called with any error being NaN, but not change internal states for fast recovery afterwards.