### PR TITLE
Remove unused class variables

### DIFF
--- a/control_toolbox/include/control_filters/exponential_filter.hpp
+++ b/control_toolbox/include/control_filters/exponential_filter.hpp
@@ -64,7 +64,6 @@ public:
   bool update(const T & data_in, T & data_out) override;
 
 private:
-  rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<rclcpp::Logger> logger_;
   std::shared_ptr<exponential_filter::ParamListener> parameter_handler_;
   exponential_filter::Params parameters_;

--- a/control_toolbox/include/control_filters/rate_limiter.hpp
+++ b/control_toolbox/include/control_filters/rate_limiter.hpp
@@ -62,7 +62,6 @@ public:
   bool update(const T & data_in, T & data_out) override;
 
 private:
-  rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<rclcpp::Logger> logger_;
   std::shared_ptr<rate_limiter::ParamListener> parameter_handler_;
   rate_limiter::Params parameters_;
@@ -74,7 +73,6 @@ private:
 template <typename T>
 bool RateLimiter<T>::configure()
 {
-  clock_ = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   logger_.reset(
     new rclcpp::Logger(this->logging_interface_->get_logger().get_child(this->filter_name_)));
 


### PR DESCRIPTION
While reviewing #162 I realized that we have somewhere `clock_` member variables, but never use them.