### PR TITLE
Add std::vector<double> option to the low pass filter

### DIFF
--- a/control_toolbox/control_filters.xml
+++ b/control_toolbox/control_filters.xml
@@ -18,6 +18,13 @@
           This is a low pass filter working with a double value.
         </description>
       </class>
+      <class name="control_filters/LowPassFilterVectorDouble"
+             type="control_filters::LowPassFilter&lt;std::vector&lt;double&gt;&gt;"
+             base_class_type="filters::FilterBase&lt;std::vector&lt;double&gt;&gt;">
+        <description>
+          This is a low pass filter working with a std::vector double value.
+        </description>
+      </class>
       <class name="control_filters/LowPassFilterWrench"
              type="control_filters::LowPassFilter&lt;geometry_msgs::msg::WrenchStamped&gt;"
              base_class_type="filters::FilterBase&lt;geometry_msgs::msg::WrenchStamped&gt;">

--- a/control_toolbox/include/control_filters/low_pass_filter.hpp
+++ b/control_toolbox/include/control_filters/low_pass_filter.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "filters/filter_base.hpp"
 #include "geometry_msgs/msg/wrench_stamped.hpp"

--- a/control_toolbox/include/control_filters/low_pass_filter.hpp
+++ b/control_toolbox/include/control_filters/low_pass_filter.hpp
@@ -153,6 +153,26 @@ inline bool LowPassFilter<geometry_msgs::msg::WrenchStamped>::update(
   return lpf_->update(data_in, data_out);
 }
 
+template <>
+inline bool LowPassFilter<std::vector<double>>::update(
+  const std::vector<double> & data_in, std::vector<double> & data_out)
+{
+  if (!this->configured_ || !lpf_ || !lpf_->is_configured())
+  {
+    throw std::runtime_error("Filter is not configured");
+  }
+
+  // Update internal parameters if required
+  if (parameter_handler_->is_old(parameters_))
+  {
+    parameters_ = parameter_handler_->get_params();
+    lpf_->set_params(
+      parameters_.sampling_frequency, parameters_.damping_frequency, parameters_.damping_intensity);
+  }
+
+  return lpf_->update(data_in, data_out);
+}
+
 template <typename T>
 bool LowPassFilter<T>::update(const T & data_in, T & data_out)
 {

--- a/control_toolbox/include/control_toolbox/low_pass_filter.hpp
+++ b/control_toolbox/include/control_toolbox/low_pass_filter.hpp
@@ -230,7 +230,7 @@ inline bool LowPassFilter<std::vector<double>>::update(
   {
     data_out[i] = b1_ * old_value[i] + a1_ * filtered_old_value[i];
     filtered_old_value[i] = data_out[i];
-    old_value[i] = data_in[i];
+    if (std::isfinite(data_in[i])) old_value[i] = data_in[i];
   }
 
   return true;
@@ -255,7 +255,7 @@ bool LowPassFilter<T>::update(const T & data_in, T & data_out)
   // Filter
   data_out = b1_ * old_value + a1_ * filtered_old_value;
   filtered_old_value = data_out;
-  old_value = data_in;
+  if (std::isfinite(data_in)) old_value = data_in;
 
   return true;
 }

--- a/control_toolbox/include/control_toolbox/low_pass_filter.hpp
+++ b/control_toolbox/include/control_toolbox/low_pass_filter.hpp
@@ -18,6 +18,7 @@
 #include <Eigen/Dense>
 
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>

--- a/control_toolbox/include/control_toolbox/low_pass_filter.hpp
+++ b/control_toolbox/include/control_toolbox/low_pass_filter.hpp
@@ -245,7 +245,7 @@ bool LowPassFilter<T>::update(const T & data_in, T & data_out)
   }
   // If this is the first call to update initialize the filter at the current state
   // so that we dont apply an impulse to the data.
-  if (filtered_value == std::numeric_limits<T>::quiet_NaN())
+  if (std::isnan(filtered_value))
   {
     filtered_value = data_in;
     filtered_old_value = data_in;

--- a/control_toolbox/src/control_filters/low_pass_filter.cpp
+++ b/control_toolbox/src/control_filters/low_pass_filter.cpp
@@ -19,5 +19,8 @@
 PLUGINLIB_EXPORT_CLASS(control_filters::LowPassFilter<double>, filters::FilterBase<double>)
 
 PLUGINLIB_EXPORT_CLASS(
+  control_filters::LowPassFilter<std::vector<double>>, filters::FilterBase<std::vector<double>>)
+
+PLUGINLIB_EXPORT_CLASS(
   control_filters::LowPassFilter<geometry_msgs::msg::WrenchStamped>,
   filters::FilterBase<geometry_msgs::msg::WrenchStamped>)

--- a/control_toolbox/test/control_filters/test_load_low_pass_filter.cpp
+++ b/control_toolbox/test/control_filters/test_load_low_pass_filter.cpp
@@ -43,6 +43,28 @@ TEST(TestLoadLowPassFilter, load_low_pass_filter_double)
   rclcpp::shutdown();
 }
 
+TEST(TestLoadLowPassFilter, load_low_pass_filter_vector_double)
+{
+  rclcpp::init(0, nullptr);
+
+  pluginlib::ClassLoader<filters::FilterBase<std::vector<double>>> filter_loader(
+    "filters", "filters::FilterBase<std::vector<double>>");
+  std::shared_ptr<filters::FilterBase<std::vector<double>>> filter;
+  auto available_classes = filter_loader.getDeclaredClasses();
+  std::stringstream sstr;
+  sstr << "available filters:" << std::endl;
+  for (const auto & available_class : available_classes)
+  {
+    sstr << "  " << available_class << std::endl;
+  }
+
+  std::string filter_type = "control_filters/LowPassFilterVectorDouble";
+  ASSERT_TRUE(filter_loader.isClassAvailable(filter_type)) << sstr.str();
+  EXPECT_NO_THROW(filter = filter_loader.createSharedInstance(filter_type));
+
+  rclcpp::shutdown();
+}
+
 TEST(TestLoadLowPassFilter, load_low_pass_filter_wrench)
 {
   rclcpp::init(0, nullptr);


### PR DESCRIPTION
This PR adds the option to create a `LowPassFilter` object with type `std::vector<double>` (seeing that most system interfaces are this type :smile: )

The velocity data from my robot is noisy so I needed to clean it up
![image](https://github.com/user-attachments/assets/af984c93-11b5-4b89-9acb-851301c6d255)
to
![image](https://github.com/user-attachments/assets/b3547715-1f33-40ca-abad-165218fb81b6)
