### PR TITLE
Add compatibility build workflow

### DIFF
--- a/.github/workflows/rolling-compatibility-build.yml
+++ b/.github/workflows/rolling-compatibility-build.yml
@@ -1,0 +1,30 @@
+name: Rolling - Check Compatibility
+# author: Christoph Froehlich <christoph.froehlich@ait.ac.at>
+# description: 'Build & test the rolling version on earlier distros.'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - ros2-master
+  push:
+    branches:
+      - ros2-master
+
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on ros2-master branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+
+jobs:
+  build:
+    uses: ros-controls/ros2_control_ci/.github/workflows/reusable-industrial-ci-with-cache.yml@master
+    strategy:
+      fail-fast: false
+      matrix:
+        ROS_DISTRO: [humble, jazzy, kilted]
+    with:
+      ros_distro: ${{ matrix.ROS_DISTRO }}
+      ros_repo: testing
+      upstream_workspace: control_toolbox.rolling.repos
+      ref_for_scheduled_build: master


### PR DESCRIPTION
Rolling testing fails because realtime_tools is broken buildfarm