### PR TITLE
Add docs for control.ros.org

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,11 @@ repos:
     rev: v1.1.2
     hooks:
       - id: doc8
-        args: ['--max-line-length=100', '--ignore=D001']
+        args: [
+          '--max-line-length=100',
+          '--ignore=D001',
+          '--ignore-path=doc/index.rst' # D000 fails
+          ]
         exclude: CHANGELOG\.rst$
 
   - repo: https://github.com/pre-commit/pygrep-hooks

--- a/doc/control_filters.md
+++ b/doc/control_filters.md
@@ -1,6 +1,6 @@
 # Control filters
 
-Implement filter plugins for control purposes as https://index.ros.org/r/filters/github-ros-filters/
+Implement filter plugins for control purposes as [ros/filters](https://github.com/ros/filters)
 
 ## Available filters
 
@@ -13,18 +13,18 @@ Implement filter plugins for control purposes as https://index.ros.org/r/filters
 
 This filter implements an algorithm compensating for the gravity forces acting at the center of gravity (CoG) of a known mass, computed at a `sensor_frame` and applied to a `data_in` wrench.
 
- The filter relies on tf2, and might fail if transforms are missing.
+The filter relies on tf2, and might fail if transforms are missing.
 
- Note that, for convenience, the filter can perform additional frame changes if data_out frame id is given.
+Note that, for convenience, the filter can perform additional frame changes if data_out frame id is given.
 
-### Required parameters
+### GC: Required parameters
 
 * `world_frame` (&Rscr;<sub>w</sub>): frame in which the `CoG.force` is represented.
 * `sensor_frame` (&Rscr;<sub>s</sub>): frame in which the `CoG.pos` is defined
 * `CoG.pos` (p<sub>s</sub>): position of the CoG of the mass the filter should compensate for
 * `CoG.force` (g<sub>w</sub>): constant (but updatable) force of gravity at the Cog (typically m.G), defined along axes of the `world_frame`
 
-### Algorithm
+### GC: Algorithm
 
 Given
 
@@ -68,13 +68,13 @@ Remarks :
 This filter implements a low-pass filter in the form of an [IIR filter](https://en.wikipedia.org/wiki/Infinite_impulse_response), applied to a `data_in` (double or wrench).
 The feedforward and feedback coefficients of the IIR filter are computed from the low-pass filter parameters.
 
-### Required parameters
+### LPF: Required parameters
 
 * sampling frequency as `sf`
 * damping frequency as `df`
 * damping intensity as `di`
 
-### Algorithm
+### LPF: Algorithm
 
 Given
 
@@ -93,9 +93,9 @@ with
 
 ## Exponential filter
 
-### Required parameters
+### EF: Required parameters
 * `alpha`: the exponential decay factor
 
-### Algorithm
+### EF: Algorithm
 
   smoothed_value  = alpha * current_value + (1 - alpha) * last_smoothed_value;

--- a/doc/control_toolbox.md
+++ b/doc/control_toolbox.md
@@ -1,0 +1,3 @@
+# Base classes
+
+Tbd.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,11 @@
+:github_url: https://github.com/ros-controls/control_toolbox/blob/{REPOS_FILE_BRANCH}/doc/index.rst
+
+control_toolbox
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This package contains several C++ classes and filter plugins useful in writing controllers.
+
+.. include:: control_toolbox.md
+   :parser: myst_parser.sphinx_
+
+.. include:: control_filters.md
+   :parser: myst_parser.sphinx_

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -1,0 +1,5 @@
+:github_url: https://github.com/ros-controls/realtime_tools/blob/{REPOS_FILE_BRANCH}/doc/migration.rst
+
+Migration Guides: Jazzy to Kilted
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This list summarizes important changes between Jazzy (previous) and Kilted (current) releases, where changes to user code might be necessary.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -1,0 +1,5 @@
+:github_url: https://github.com/ros-controls/realtime_tools/blob/{REPOS_FILE_BRANCH}/doc/release_notes.rst
+
+Release Notes: Jazzy to Kilted
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This list summarizes the changes between Jazzy (previous) and Kilted (current) releases.


### PR DESCRIPTION
No new information, just moving it to a location to include in control.ros.org

---
![image](https://github.com/user-attachments/assets/995729e3-770e-4fbb-a7f7-e4c3028a9b26)
