### PR TITLE
Cleanup saturation parameter in the methods and constructors

### DIFF
--- a/control_toolbox/include/control_toolbox/pid.hpp
+++ b/control_toolbox/include/control_toolbox/pid.hpp
@@ -276,6 +276,8 @@ public:
           //   std::to_string(u_max) + ")");
           std::cout << "Received invalid u_min and u_max values: " << "u_min: " << u_min
                     << ", u_max: " << u_max << ". Setting saturation to false." << std::endl;
+          u_max_ = std::numeric_limits<double>::infinity();
+          u_min_ = -std::numeric_limits<double>::infinity();
           saturation_ = false;
         }
       }

--- a/control_toolbox/include/control_toolbox/pid.hpp
+++ b/control_toolbox/include/control_toolbox/pid.hpp
@@ -258,28 +258,22 @@ public:
       u_max_(u_max),
       u_min_(u_min),
       trk_tc_(trk_tc),
-      saturation_(false),
       antiwindup_(antiwindup),
       antiwindup_strat_(antiwindup_strat)
     {
-      saturation_ = std::isfinite(u_min) || std::isfinite(u_max);
-      if (saturation_)
+      if (std::isnan(u_min) || std::isnan(u_max))
       {
-        if (std::isnan(u_min) || std::isnan(u_max))
-        {
-          throw std::invalid_argument("Gains: u_min and u_max must not be NaN");
-        }
-        if (u_min > u_max)
-        {
-          // throw std::invalid_argument(
-          //   "Gains: u_min (" + std::to_string(u_min) + ") must not be greater than u_max (" +
-          //   std::to_string(u_max) + ")");
-          std::cout << "Received invalid u_min and u_max values: " << "u_min: " << u_min
-                    << ", u_max: " << u_max << ". Setting saturation to false." << std::endl;
-          u_max_ = std::numeric_limits<double>::infinity();
-          u_min_ = -std::numeric_limits<double>::infinity();
-          saturation_ = false;
-        }
+        throw std::invalid_argument("Gains: u_min and u_max must not be NaN");
+      }
+      if (u_min > u_max)
+      {
+        // throw std::invalid_argument(
+        //   "Gains: u_min (" + std::to_string(u_min) + ") must not be greater than u_max (" +
+        //   std::to_string(u_max) + ")");
+        std::cout << "Received invalid u_min and u_max values: " << "u_min: " << u_min
+                  << ", u_max: " << u_max << ". Setting saturation to false." << std::endl;
+        u_max_ = std::numeric_limits<double>::infinity();
+        u_min_ = -std::numeric_limits<double>::infinity();
       }
     }
 
@@ -317,7 +311,7 @@ public:
       std::cout << "Gains: p: " << p_gain_ << ", i: " << i_gain_ << ", d: " << d_gain_
                 << ", i_max: " << i_max_ << ", i_min: " << i_min_ << ", u_max: " << u_max_
                 << ", u_min: " << u_min_ << ", trk_tc: " << trk_tc_
-                << ", saturation: " << saturation_ << ", antiwindup: " << antiwindup_
+                << ", antiwindup: " << antiwindup_
                 << ", antiwindup_strat: " << antiwindup_strat_.to_string() << std::endl;
     }
 
@@ -329,7 +323,6 @@ public:
     double u_max_ = std::numeric_limits<double>::infinity();  /**< Maximum allowable output. */
     double u_min_ = -std::numeric_limits<double>::infinity(); /**< Minimum allowable output. */
     double trk_tc_ = 0.0;                                     /**< Tracking time constant. */
-    bool saturation_ = false;                                 /**< Saturation. */
     bool antiwindup_ = false;                                 /**< Anti-windup. */
     AntiwindupStrategy antiwindup_strat_ = AntiwindupStrategy::NONE; /**< Anti-windup strategy. */
   };
@@ -536,8 +529,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup Anti-windup functionality. When set to true, limits
         the integral error to prevent windup; otherwise, constrains the
         integral contribution to the control output. i_max and
@@ -550,8 +541,7 @@ public:
   [[deprecated("Use get_gains overload with AntiwindupStrategy only.")]]
   void get_gains(
     double & p, double & i, double & d, double & i_max, double & i_min, double & u_max,
-    double & u_min, double & trk_tc, bool & saturation, bool & antiwindup,
-    AntiwindupStrategy & antiwindup_strat);
+    double & u_min, double & trk_tc, bool & antiwindup, AntiwindupStrategy & antiwindup_strat);
 
   /*!
    * \brief Get PID gains for the controller (preferred).
@@ -562,15 +552,13 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup_strat Specifies the anti-windup strategy. Options: 'back_calculation',
         'conditional_integration', or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.
    */
   void get_gains(
     double & p, double & i, double & d, double & u_max, double & u_min, double & trk_tc,
-    bool & saturation, AntiwindupStrategy & antiwindup_strat);
+    AntiwindupStrategy & antiwindup_strat);
 
   /*!
    * \brief Get PID gains for the controller.

--- a/control_toolbox/include/control_toolbox/pid.hpp
+++ b/control_toolbox/include/control_toolbox/pid.hpp
@@ -606,8 +606,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup Anti-windup functionality. When set to true, limits
         the integral error to prevent windup; otherwise, constrains the
         integral contribution to the control output. i_max and
@@ -635,8 +633,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup_strat Specifies the anti-windup strategy. Options: 'back_calculation',
         'conditional_integration', or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.

--- a/control_toolbox/include/control_toolbox/pid.hpp
+++ b/control_toolbox/include/control_toolbox/pid.hpp
@@ -35,6 +35,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <iostream>
 #include <limits>
 #include <string>
 
@@ -261,15 +262,21 @@ public:
       antiwindup_(antiwindup),
       antiwindup_strat_(antiwindup_strat)
     {
-      if (std::isfinite(u_min) && std::isfinite(u_max) && u_min != 0.0 && u_max != 0.0)
+      saturation_ = std::isfinite(u_min) || std::isfinite(u_max);
+      if (saturation_)
       {
-        saturation_ = true;
-
+        if (std::isnan(u_min) || std::isnan(u_max))
+        {
+          throw std::invalid_argument("Gains: u_min and u_max must not be NaN");
+        }
         if (u_min > u_max)
         {
-          throw std::invalid_argument(
-            "Gains: u_min (" + std::to_string(u_min) + ") must not be greater than u_max (" +
-            std::to_string(u_max) + ")");
+          // throw std::invalid_argument(
+          //   "Gains: u_min (" + std::to_string(u_min) + ") must not be greater than u_max (" +
+          //   std::to_string(u_max) + ")");
+          std::cout << "Received invalid u_min and u_max values: " << "u_min: " << u_min
+                    << ", u_max: " << u_max << ". Setting saturation to false." << std::endl;
+          saturation_ = false;
         }
       }
     }
@@ -301,6 +308,15 @@ public:
       "Use constructor with AntiwindupStrategy only. The default constructor might be deleted in "
       "future")]] Gains()
     {
+    }
+
+    void print() const
+    {
+      std::cout << "Gains: p: " << p_gain_ << ", i: " << i_gain_ << ", d: " << d_gain_
+                << ", i_max: " << i_max_ << ", i_min: " << i_min_ << ", u_max: " << u_max_
+                << ", u_min: " << u_min_ << ", trk_tc: " << trk_tc_
+                << ", saturation: " << saturation_ << ", antiwindup: " << antiwindup_
+                << ", antiwindup_strat: " << antiwindup_strat_.to_string() << std::endl;
     }
 
     double p_gain_ = 0.0; /**< Proportional gain. */

--- a/control_toolbox/include/control_toolbox/pid.hpp
+++ b/control_toolbox/include/control_toolbox/pid.hpp
@@ -34,6 +34,7 @@
 #define CONTROL_TOOLBOX__PID_HPP_
 
 #include <chrono>
+#include <cmath>
 #include <limits>
 #include <string>
 
@@ -194,17 +195,9 @@ public:
    */
     [[deprecated("Use constructor with AntiwindupStrategy instead.")]]
     Gains(double p, double i, double d, double i_max, double i_min)
-    : p_gain_(p),
-      i_gain_(i),
-      d_gain_(d),
-      i_max_(i_max),
-      i_min_(i_min),
-      u_max_(0.0),
-      u_min_(0.0),
-      trk_tc_(0.0),
-      saturation_(false),
-      antiwindup_(true),
-      antiwindup_strat_(AntiwindupStrategy::NONE)
+    : Gains(
+        p, i, d, i_max, i_min, std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(), 0.0, true, AntiwindupStrategy::NONE)
     {
     }
 
@@ -224,17 +217,9 @@ public:
    */
     [[deprecated("Use constructor with AntiwindupStrategy instead.")]]
     Gains(double p, double i, double d, double i_max, double i_min, bool antiwindup)
-    : p_gain_(p),
-      i_gain_(i),
-      d_gain_(d),
-      i_max_(i_max),
-      i_min_(i_min),
-      u_max_(0.0),
-      u_min_(0.0),
-      trk_tc_(0.0),
-      saturation_(false),
-      antiwindup_(antiwindup),
-      antiwindup_strat_(AntiwindupStrategy::NONE)
+    : Gains(
+        p, i, d, i_max, i_min, std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(), 0.0, antiwindup, AntiwindupStrategy::NONE)
     {
     }
 
@@ -250,8 +235,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup Anti-windup functionality. When set to true, limits
         the integral error to prevent windup; otherwise, constrains the
         integral contribution to the control output. i_max and
@@ -265,7 +248,7 @@ public:
     [[deprecated("Use constructor with AntiwindupStrategy only.")]]
     Gains(
       double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-      double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat)
+      double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat)
     : p_gain_(p),
       i_gain_(i),
       d_gain_(d),
@@ -274,10 +257,21 @@ public:
       u_max_(u_max),
       u_min_(u_min),
       trk_tc_(trk_tc),
-      saturation_(saturation),
+      saturation_(false),
       antiwindup_(antiwindup),
       antiwindup_strat_(antiwindup_strat)
     {
+      if (std::isfinite(u_min) && std::isfinite(u_max) && u_min != 0.0 && u_max != 0.0)
+      {
+        saturation_ = true;
+
+        if (u_min > u_max)
+        {
+          throw std::invalid_argument(
+            "Gains: u_min (" + std::to_string(u_min) + ") must not be greater than u_max (" +
+            std::to_string(u_max) + ")");
+        }
+      }
     }
 
     /*!
@@ -290,57 +284,36 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup_strat Specifies the anti-windup strategy. Options: 'back_calculation',
         'conditional_integration', or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.
    *
    */
     Gains(
-      double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+      double p, double i, double d, double u_max, double u_min, double trk_tc,
       AntiwindupStrategy antiwindup_strat)
-    : p_gain_(p),
-      i_gain_(i),
-      d_gain_(d),
-      i_max_(0.0),
-      i_min_(0.0),
-      u_max_(u_max),
-      u_min_(u_min),
-      trk_tc_(trk_tc),
-      saturation_(saturation),
-      antiwindup_(false),
-      antiwindup_strat_(antiwindup_strat)
+    : Gains(p, i, d, 0.0, 0.0, u_max, u_min, trk_tc, false, antiwindup_strat)
     {
     }
 
     // Default constructor
-    Gains()
-    : p_gain_(0.0),
-      i_gain_(0.0),
-      d_gain_(0.0),
-      i_max_(0.0),
-      i_min_(0.0),
-      u_max_(0.0),
-      u_min_(0.0),
-      trk_tc_(0.0),
-      saturation_(false),
-      antiwindup_(false),
-      antiwindup_strat_(AntiwindupStrategy::NONE)
+    [[deprecated(
+      "Use constructor with AntiwindupStrategy only. The default constructor might be deleted in "
+      "future")]] Gains()
     {
     }
 
-    double p_gain_;                       /**< Proportional gain. */
-    double i_gain_;                       /**< Integral gain. */
-    double d_gain_;                       /**< Derivative gain. */
-    double i_max_;                        /**< Maximum allowable integral term. */
-    double i_min_;                        /**< Minimum allowable integral term. */
-    double u_max_;                        /**< Maximum allowable output. */
-    double u_min_;                        /**< Minimum allowable output. */
-    double trk_tc_;                       /**< Tracking time constant. */
-    bool saturation_;                     /**< Saturation. */
-    bool antiwindup_;                     /**< Anti-windup. */
-    AntiwindupStrategy antiwindup_strat_; /**< Anti-windup strategy. */
+    double p_gain_ = 0.0; /**< Proportional gain. */
+    double i_gain_ = 0.0; /**< Integral gain. */
+    double d_gain_ = 0.0; /**< Derivative gain. */
+    double i_max_ = 0.0;  /**< Maximum allowable integral term. */
+    double i_min_ = 0.0;  /**< Minimum allowable integral term. */
+    double u_max_ = std::numeric_limits<double>::infinity();  /**< Maximum allowable output. */
+    double u_min_ = -std::numeric_limits<double>::infinity(); /**< Minimum allowable output. */
+    double trk_tc_ = 0.0;                                     /**< Tracking time constant. */
+    bool saturation_ = false;                                 /**< Saturation. */
+    bool antiwindup_ = false;                                 /**< Anti-windup. */
+    AntiwindupStrategy antiwindup_strat_ = AntiwindupStrategy::NONE; /**< Anti-windup strategy. */
   };
 
   /*!
@@ -376,8 +349,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup Anti-windup functionality. When set to true, limits
         the integral error to prevent windup; otherwise, constrains the
         integral contribution to the control output. i_max and
@@ -392,7 +363,7 @@ public:
   [[deprecated("Use constructor with AntiwindupStrategy only.")]]
   Pid(
     double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-    double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+    double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
 
   /*!
    * \brief Constructor, initialize Pid-gains and term limits.
@@ -404,8 +375,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup_strat Specifies the anti-windup strategy. Options: 'back_calculation',
         'conditional_integration', or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.
@@ -413,7 +382,7 @@ public:
    * \throws An std::invalid_argument exception is thrown if u_min > u_max
    */
   Pid(
-    double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+    double p, double i, double d, double u_max, double u_min, double trk_tc,
     AntiwindupStrategy antiwindup_strat);
 
   /*!
@@ -458,8 +427,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup Anti-windup functionality. When set to true, limits
         the integral error to prevent windup; otherwise, constrains the
         integral contribution to the control output. i_max and
@@ -474,7 +441,7 @@ public:
   [[deprecated("Use initialize with AntiwindupStrategy only.")]]
   void initialize(
     double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-    double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+    double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
 
   /*!
    * \brief Initialize Pid-gains and term limits.
@@ -486,8 +453,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup_strat Specifies the anti-windup strategy. Options: 'back_calculation',
         'conditional_integration', or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.
@@ -495,7 +460,7 @@ public:
    * \note New gains are not applied if i_min_ > i_max_ or u_min > u_max
    */
   void initialize(
-    double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+    double p, double i, double d, double u_max, double u_min, double trk_tc,
     AntiwindupStrategy antiwindup_strat);
 
   /*!
@@ -639,7 +604,7 @@ public:
   [[deprecated("Use set_gains with AntiwindupStrategy only.")]]
   void set_gains(
     double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-    double trk_tc = 0.0, bool saturation = false, bool antiwindup = false,
+    double trk_tc = 0.0, bool antiwindup = false,
     AntiwindupStrategy antiwindup_strat = AntiwindupStrategy::NONE);
 
   /*!
@@ -661,7 +626,7 @@ public:
    * \note New gains are not applied if i_min_ > i_max_ or u_min > u_max
    */
   void set_gains(
-    double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+    double p, double i, double d, double u_max, double u_min, double trk_tc,
     AntiwindupStrategy antiwindup_strat);
 
   /*!

--- a/control_toolbox/include/control_toolbox/pid.hpp
+++ b/control_toolbox/include/control_toolbox/pid.hpp
@@ -267,9 +267,6 @@ public:
       }
       if (u_min > u_max)
       {
-        // throw std::invalid_argument(
-        //   "Gains: u_min (" + std::to_string(u_min) + ") must not be greater than u_max (" +
-        //   std::to_string(u_max) + ")");
         std::cout << "Received invalid u_min and u_max values: " << "u_min: " << u_min
                   << ", u_max: " << u_max << ". Setting saturation to false." << std::endl;
         u_max_ = std::numeric_limits<double>::infinity();

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -255,8 +255,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup Anti-windup functionality. When set to true, limits
         the integral error to prevent windup; otherwise, constrains the
         integral contribution to the control output. i_max and
@@ -290,8 +288,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup_strat Specifies the anti-windup strategy. Options: 'back_calculation',
         'conditional_integration', or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -282,7 +282,7 @@ public:
   [[deprecated("Use set_gains with AntiwindupStrategy only.")]]
   void set_gains(
     double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-    double trk_tc = 0.0, bool saturation = false, bool antiwindup = false,
+    double trk_tc = 0.0, bool antiwindup = false,
     AntiwindupStrategy antiwindup_strat = AntiwindupStrategy::NONE);
 
   /*!
@@ -304,7 +304,7 @@ public:
    * \note New gains are not applied if u_min_ > u_max_.
    */
   void set_gains(
-    double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+    double p, double i, double d, double u_max, double u_min, double trk_tc,
     AntiwindupStrategy antiwindup_strat);
 
   /*!

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -133,8 +133,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup Anti-windup functionality. When set to true, limits
         the integral error to prevent windup; otherwise, constrains the
         integral contribution to the control output. i_max and
@@ -155,8 +153,7 @@ public:
   [[deprecated("Use initialize_from_args with AntiwindupStrategy only.")]]
   void initialize_from_args(
     double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-    double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat,
-    bool save_i_term);
+    double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat, bool save_i_term);
 
   /*!
    * \brief Initialize the PID controller and set the parameters.
@@ -168,8 +165,6 @@ public:
    * \param u_min Lower output clamp.
    * \param trk_tc Specifies the tracking time constant for the 'back_calculation' strategy. If set
    *    to 0.0 when this strategy is selected, a recommended default value will be applied.
-   * \param saturation Enables output saturation. When true, the controller output is
-        clamped between u_max and u_min.
    * \param antiwindup_strat Specifies the anti-windup strategy. Options: 'back_calculation',
         'conditional_integration', or 'none'. Note that the 'back_calculation' strategy use the
         tracking_time_constant parameter to tune the anti-windup behavior.
@@ -178,7 +173,7 @@ public:
    * \note New gains are not applied if u_min_ > u_max_.
    */
   void initialize_from_args(
-    double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+    double p, double i, double d, double u_max, double u_min, double trk_tc,
     AntiwindupStrategy antiwindup_strat, bool save_i_term);
 
   /*!

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -271,7 +271,7 @@ void Pid::set_gains(const Gains & gains_in)
   {
     std::cout << "Received u_min > u_max, skip new gains" << std::endl;
   }
-  else if (std::isnan(gains.u_min_) || std::isnan(gains.u_max_))
+  else if (std::isnan(gains_in.u_min_) || std::isnan(gains_in.u_max_))
   {
     std::cout << "Received NaN for u_min or u_max, skipping new gains" << std::endl;
   }

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -406,7 +406,7 @@ double Pid::compute_command(double error, double error_dot, const double & dt_s)
     cmd_unsat_ = p_term + i_term_ + d_term;
   }
 
-  if (gains.saturation_ == true)
+  if (gains.saturation_)
   {
     // Limit cmd_ if saturation is enabled
     cmd_ = std::clamp(cmd_unsat_, gains.u_min_, gains.u_max_);

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -45,17 +45,20 @@
 
 namespace control_toolbox
 {
+constexpr double UMAX_INFINITY = std::numeric_limits<double>::infinity();
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 Pid::Pid(double p, double i, double d, double i_max, double i_min, bool antiwindup)
-: Pid(p, i, d, i_max, i_min, 0.0, 0.0, 0.0, false, antiwindup, AntiwindupStrategy::NONE)
+: Pid(
+    p, i, d, i_max, i_min, UMAX_INFINITY, -UMAX_INFINITY, 0.0, antiwindup, AntiwindupStrategy::NONE)
 {
 }
 #pragma GCC diagnostic pop
 
 Pid::Pid(
   double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat)
+  double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat)
 : gains_buffer_()
 {
   if (i_min > i_max)
@@ -68,7 +71,7 @@ Pid::Pid(
   }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  set_gains(p, i, d, i_max, i_min, u_max, u_min, trk_tc, saturation, antiwindup, antiwindup_strat);
+  set_gains(p, i, d, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 #pragma GCC diagnostic pop
 
   // Initialize saved i-term values
@@ -78,7 +81,7 @@ Pid::Pid(
 }
 
 Pid::Pid(
-  double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+  double p, double i, double d, double u_max, double u_min, double trk_tc,
   AntiwindupStrategy antiwindup_strat)
 : gains_buffer_()
 {
@@ -86,7 +89,7 @@ Pid::Pid(
   {
     throw std::invalid_argument("received u_min > u_max");
   }
-  set_gains(p, i, d, u_max, u_min, trk_tc, saturation, antiwindup_strat);
+  set_gains(p, i, d, u_max, u_min, trk_tc, antiwindup_strat);
 
   // Initialize saved i-term values
   clear_saved_iterm();
@@ -112,7 +115,9 @@ void Pid::initialize(double p, double i, double d, double i_max, double i_min, b
 {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  initialize(p, i, d, i_max, i_min, 0.0, 0.0, 0.0, false, antiwindup, AntiwindupStrategy::NONE);
+  initialize(
+    p, i, d, i_max, i_min, UMAX_INFINITY, -UMAX_INFINITY, 0.0, antiwindup,
+    AntiwindupStrategy::NONE);
 #pragma GCC diagnostic pop
 
   reset();
@@ -120,21 +125,21 @@ void Pid::initialize(double p, double i, double d, double i_max, double i_min, b
 
 void Pid::initialize(
   double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat)
+  double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat)
 {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  set_gains(p, i, d, i_max, i_min, u_max, u_min, trk_tc, saturation, antiwindup, antiwindup_strat);
+  set_gains(p, i, d, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 #pragma GCC diagnostic pop
 
   reset();
 }
 
 void Pid::initialize(
-  double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+  double p, double i, double d, double u_max, double u_min, double trk_tc,
   AntiwindupStrategy antiwindup_strat)
 {
-  set_gains(p, i, d, u_max, u_min, trk_tc, saturation, antiwindup_strat);
+  set_gains(p, i, d, u_max, u_min, trk_tc, antiwindup_strat);
 
   reset();
 }
@@ -227,7 +232,9 @@ Pid::Gains Pid::get_gains() { return *gains_buffer_.readFromRT(); }
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 void Pid::set_gains(double p, double i, double d, double i_max, double i_min, bool antiwindup)
 {
-  set_gains(p, i, d, i_max, i_min, 0.0, 0.0, 0.0, false, antiwindup, AntiwindupStrategy::NONE);
+  set_gains(
+    p, i, d, i_max, i_min, UMAX_INFINITY, -UMAX_INFINITY, 0.0, antiwindup,
+    AntiwindupStrategy::NONE);
 }
 #pragma GCC diagnostic pop
 
@@ -235,17 +242,16 @@ void Pid::set_gains(double p, double i, double d, double i_max, double i_min, bo
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 void Pid::set_gains(
   double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat)
+  double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat)
 {
-  Gains gains(
-    p, i, d, i_max, i_min, u_max, u_min, trk_tc, saturation, antiwindup, antiwindup_strat);
+  Gains gains(p, i, d, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 
   set_gains(gains);
 }
 #pragma GCC diagnostic pop
 
 void Pid::set_gains(
-  double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+  double p, double i, double d, double u_max, double u_min, double trk_tc,
   AntiwindupStrategy antiwindup_strat)
 {
   double i_min = 0.0;
@@ -254,8 +260,7 @@ void Pid::set_gains(
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  Gains gains(
-    p, i, d, i_max, i_min, u_max, u_min, trk_tc, saturation, antiwindup, antiwindup_strat);
+  Gains gains(p, i, d, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 #pragma GCC diagnostic pop
 
   set_gains(gains);

--- a/control_toolbox/src/pid.cpp
+++ b/control_toolbox/src/pid.cpp
@@ -265,11 +265,15 @@ void Pid::set_gains(const Gains & gains_in)
 {
   if (gains_in.i_min_ > gains_in.i_max_)
   {
-    std::cout << "received i_min > i_max, skip new gains\n";
+    std::cout << "Received i_min > i_max, skip new gains" << std::endl;
   }
   else if (gains_in.u_min_ > gains_in.u_max_)
   {
-    std::cout << "received u_min > u_max, skip new gains\n";
+    std::cout << "Received u_min > u_max, skip new gains" << std::endl;
+  }
+  else if (std::isnan(gains.u_min_) || std::isnan(gains.u_max_))
+  {
+    std::cout << "Received NaN for u_min or u_max, skipping new gains" << std::endl;
   }
   else
   {

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -633,11 +633,11 @@ void PidROS::set_parameter_event_callback()
     {
       if (gains.i_min_ > gains.i_max_)
       {
-        RCLCPP_ERROR(node_logging_->get_logger(), "received i_min > i_max, skip new gains");
+        RCLCPP_ERROR(node_logging_->get_logger(), "Received i_min > i_max, skip new gains");
       }
       else if (gains.u_min_ > gains.u_max_)
       {
-        RCLCPP_ERROR(node_logging_->get_logger(), "received u_min > u_max, skip new gains");
+        RCLCPP_ERROR(node_logging_->get_logger(), "Received u_min > u_max, skip new gains");
       }
       else
       {

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -272,8 +272,8 @@ void PidROS::initialize_from_args(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   initialize_from_args(
-    p, i, d, i_max, i_min, UMAX_INFINITY, -UMAX_INFINITY, 0.0, false, antiwindup,
-    AntiwindupStrategy::NONE, false);
+    p, i, d, i_max, i_min, UMAX_INFINITY, -UMAX_INFINITY, 0.0, antiwindup, AntiwindupStrategy::NONE,
+    false);
 #pragma GCC diagnostic pop
 }
 
@@ -283,15 +283,14 @@ void PidROS::initialize_from_args(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   initialize_from_args(
-    p, i, d, i_max, i_min, UMAX_INFINITY, -UMAX_INFINITY, 0.0, false, antiwindup,
-    AntiwindupStrategy::NONE, save_i_term);
+    p, i, d, i_max, i_min, UMAX_INFINITY, -UMAX_INFINITY, 0.0, antiwindup, AntiwindupStrategy::NONE,
+    save_i_term);
 #pragma GCC diagnostic pop
 }
 
 void PidROS::initialize_from_args(
   double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat,
-  bool save_i_term)
+  double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat, bool save_i_term)
 {
   if (i_min > i_max)
   {
@@ -314,19 +313,21 @@ void PidROS::initialize_from_args(
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     pid_.initialize(p, i, d, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 #pragma GCC diagnostic pop
+    const Pid::Gains gains = pid_.get_gains();
 
-    declare_param(param_prefix_ + "p", rclcpp::ParameterValue(p));
-    declare_param(param_prefix_ + "i", rclcpp::ParameterValue(i));
-    declare_param(param_prefix_ + "d", rclcpp::ParameterValue(d));
-    declare_param(param_prefix_ + "i_clamp_max", rclcpp::ParameterValue(i_max));
-    declare_param(param_prefix_ + "i_clamp_min", rclcpp::ParameterValue(i_min));
-    declare_param(param_prefix_ + "u_clamp_max", rclcpp::ParameterValue(u_max));
-    declare_param(param_prefix_ + "u_clamp_min", rclcpp::ParameterValue(u_min));
-    declare_param(param_prefix_ + "tracking_time_constant", rclcpp::ParameterValue(trk_tc));
-    declare_param(param_prefix_ + "saturation", rclcpp::ParameterValue(saturation));
-    declare_param(param_prefix_ + "antiwindup", rclcpp::ParameterValue(antiwindup));
+    declare_param(param_prefix_ + "p", rclcpp::ParameterValue(gains.p_gain_));
+    declare_param(param_prefix_ + "i", rclcpp::ParameterValue(gains.i_gain_));
+    declare_param(param_prefix_ + "d", rclcpp::ParameterValue(gains.d_gain_));
+    declare_param(param_prefix_ + "i_clamp_max", rclcpp::ParameterValue(gains.i_max_));
+    declare_param(param_prefix_ + "i_clamp_min", rclcpp::ParameterValue(gains.i_min_));
+    declare_param(param_prefix_ + "u_clamp_max", rclcpp::ParameterValue(gains.u_max_));
+    declare_param(param_prefix_ + "u_clamp_min", rclcpp::ParameterValue(gains.u_min_));
+    declare_param(param_prefix_ + "tracking_time_constant", rclcpp::ParameterValue(gains.trk_tc_));
+    declare_param(param_prefix_ + "saturation", rclcpp::ParameterValue(gains.saturation_));
+    declare_param(param_prefix_ + "antiwindup", rclcpp::ParameterValue(gains.antiwindup_));
     declare_param(
-      param_prefix_ + "antiwindup_strategy", rclcpp::ParameterValue(antiwindup_strat.to_string()));
+      param_prefix_ + "antiwindup_strategy",
+      rclcpp::ParameterValue(gains.antiwindup_strat_.to_string()));
     declare_param(param_prefix_ + "save_i_term", rclcpp::ParameterValue(save_i_term));
 
     set_parameter_event_callback();
@@ -334,7 +335,7 @@ void PidROS::initialize_from_args(
 }
 
 void PidROS::initialize_from_args(
-  double p, double i, double d, double u_max, double u_min, double trk_tc, bool saturation,
+  double p, double i, double d, double u_max, double u_min, double trk_tc,
   AntiwindupStrategy antiwindup_strat, bool save_i_term)
 {
   if (u_min > u_max)
@@ -344,16 +345,18 @@ void PidROS::initialize_from_args(
   else
   {
     pid_.initialize(p, i, d, u_max, u_min, trk_tc, antiwindup_strat);
+    const Pid::Gains gains = pid_.get_gains();
 
-    declare_param(param_prefix_ + "p", rclcpp::ParameterValue(p));
-    declare_param(param_prefix_ + "i", rclcpp::ParameterValue(i));
-    declare_param(param_prefix_ + "d", rclcpp::ParameterValue(d));
-    declare_param(param_prefix_ + "u_clamp_max", rclcpp::ParameterValue(u_max));
-    declare_param(param_prefix_ + "u_clamp_min", rclcpp::ParameterValue(u_min));
-    declare_param(param_prefix_ + "tracking_time_constant", rclcpp::ParameterValue(trk_tc));
-    declare_param(param_prefix_ + "saturation", rclcpp::ParameterValue(saturation));
+    declare_param(param_prefix_ + "p", rclcpp::ParameterValue(gains.p_gain_));
+    declare_param(param_prefix_ + "i", rclcpp::ParameterValue(gains.i_gain_));
+    declare_param(param_prefix_ + "d", rclcpp::ParameterValue(gains.d_gain_));
+    declare_param(param_prefix_ + "u_clamp_max", rclcpp::ParameterValue(gains.u_max_));
+    declare_param(param_prefix_ + "u_clamp_min", rclcpp::ParameterValue(gains.u_min_));
+    declare_param(param_prefix_ + "tracking_time_constant", rclcpp::ParameterValue(gains.trk_tc_));
+    declare_param(param_prefix_ + "saturation", rclcpp::ParameterValue(gains.saturation_));
     declare_param(
-      param_prefix_ + "antiwindup_strategy", rclcpp::ParameterValue(antiwindup_strat.to_string()));
+      param_prefix_ + "antiwindup_strategy",
+      rclcpp::ParameterValue(gains.antiwindup_strat_.to_string()));
     declare_param(param_prefix_ + "save_i_term", rclcpp::ParameterValue(save_i_term));
 
     set_parameter_event_callback();
@@ -425,7 +428,7 @@ void PidROS::set_gains(
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     pid_.set_gains(p, i, d, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 #pragma GCC diagnostic pop
-    const Pid::Gains & gains = pid_.get_gains();
+    const Pid::Gains gains = pid_.get_gains();
 
     node_params_->set_parameters(
       {rclcpp::Parameter(param_prefix_ + "p", gains.p_gain_),
@@ -454,7 +457,7 @@ void PidROS::set_gains(
   else
   {
     pid_.set_gains(p, i, d, u_max, u_min, trk_tc, antiwindup_strat);
-    const Pid::Gains & gains = pid_.get_gains();
+    const Pid::Gains gains = pid_.get_gains();
     node_params_->set_parameters(
       {rclcpp::Parameter(param_prefix_ + "p", gains.p_gain_),
        rclcpp::Parameter(param_prefix_ + "i", gains.i_gain_),

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -563,7 +563,7 @@ void PidROS::set_parameter_event_callback()
     /// @note don't use getGains, it's rt
     Pid::Gains gains = pid_.get_gains();
     bool changed = false;
-    // THe saturation parameter is special, it can change the u_min and u_max parameters
+    // The saturation parameter is special, it can change the u_min and u_max parameters
     // so we need to check it first and then proceed with the loop, as if we update only one
     // parameter, we need to keep this logic up-to-date. So, do not move it inside the loop
     bool saturation = node_params_->get_parameter(param_prefix_ + "saturation").get_value<bool>();

--- a/control_toolbox/test/pid_ros_parameters_tests.cpp
+++ b/control_toolbox/test/pid_ros_parameters_tests.cpp
@@ -177,8 +177,8 @@ TEST(PidParametersTest, InitPidTestBadParameter)
   ASSERT_EQ(gains.d_gain_, 0.0);
   ASSERT_EQ(gains.i_max_, 0.0);
   ASSERT_EQ(gains.i_min_, 0.0);
-  ASSERT_EQ(gains.u_max_, 0.0);
-  ASSERT_EQ(gains.u_min_, 0.0);
+  ASSERT_EQ(gains.u_max_, std::numeric_limits<double>::infinity());
+  ASSERT_EQ(gains.u_min_, -std::numeric_limits<double>::infinity());
   ASSERT_EQ(gains.trk_tc_, 0.0);
   ASSERT_FALSE(gains.saturation_);
   ASSERT_FALSE(gains.antiwindup_);
@@ -403,63 +403,125 @@ TEST(PidParametersTest, SetBadParametersTest)
 
 TEST(PidParametersTest, GetParametersTest)
 {
-  rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("pid_parameters_test");
+  {
+    rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("pid_parameters_test");
 
-  TestablePidROS pid(node);
+    TestablePidROS pid(node);
 
-  const double P = 1.0;
-  const double I = 2.0;
-  const double D = 3.0;
-  const double I_MAX = 10.0;
-  const double I_MIN = -10.0;
-  const double U_MAX = 10.0;
-  const double U_MIN = -10.0;
-  const double TRK_TC = 4.0;
-  const bool SATURATION = true;
-  const bool ANTIWINDUP = true;
-  const AntiwindupStrategy ANTIWINDUP_STRAT = AntiwindupStrategy::NONE;
+    const double P = 1.0;
+    const double I = 2.0;
+    const double D = 3.0;
+    const double I_MAX = 10.0;
+    const double I_MIN = -10.0;
+    const double U_MAX = 10.0;
+    const double U_MIN = -10.0;
+    const double TRK_TC = 4.0;
+    const bool SATURATION = true;
+    const bool ANTIWINDUP = true;
+    const AntiwindupStrategy ANTIWINDUP_STRAT = AntiwindupStrategy::NONE;
 
-  pid.initialize_from_args(
-    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, AntiwindupStrategy::NONE, false);
-  pid.set_gains(P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT);
+    pid.initialize_from_args(
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, AntiwindupStrategy::NONE, false);
+    std::cout << "Setting gains with set_gains()" << std::endl;
+    pid.set_gains(P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT);
 
-  rclcpp::Parameter param;
+    rclcpp::Parameter param;
 
-  ASSERT_TRUE(node->get_parameter("p", param));
-  ASSERT_EQ(param.get_value<double>(), P);
+    ASSERT_TRUE(node->get_parameter("p", param));
+    ASSERT_EQ(param.get_value<double>(), P);
 
-  ASSERT_TRUE(node->get_parameter("i", param));
-  ASSERT_EQ(param.get_value<double>(), I);
+    ASSERT_TRUE(node->get_parameter("i", param));
+    ASSERT_EQ(param.get_value<double>(), I);
 
-  ASSERT_TRUE(node->get_parameter("d", param));
-  ASSERT_EQ(param.get_value<double>(), D);
+    ASSERT_TRUE(node->get_parameter("d", param));
+    ASSERT_EQ(param.get_value<double>(), D);
 
-  ASSERT_TRUE(node->get_parameter("i_clamp_max", param));
-  ASSERT_EQ(param.get_value<double>(), I_MAX);
+    ASSERT_TRUE(node->get_parameter("i_clamp_max", param));
+    ASSERT_EQ(param.get_value<double>(), I_MAX);
 
-  ASSERT_TRUE(node->get_parameter("i_clamp_min", param));
-  ASSERT_EQ(param.get_value<double>(), I_MIN);
+    ASSERT_TRUE(node->get_parameter("i_clamp_min", param));
+    ASSERT_EQ(param.get_value<double>(), I_MIN);
 
-  ASSERT_TRUE(node->get_parameter("u_clamp_max", param));
-  ASSERT_EQ(param.get_value<double>(), U_MAX);
+    ASSERT_TRUE(node->get_parameter("u_clamp_max", param));
+    ASSERT_EQ(param.get_value<double>(), U_MAX);
 
-  ASSERT_TRUE(node->get_parameter("u_clamp_min", param));
-  ASSERT_EQ(param.get_value<double>(), U_MIN);
+    ASSERT_TRUE(node->get_parameter("u_clamp_min", param));
+    ASSERT_EQ(param.get_value<double>(), U_MIN);
 
-  ASSERT_TRUE(node->get_parameter("tracking_time_constant", param));
-  ASSERT_EQ(param.get_value<double>(), TRK_TC);
+    ASSERT_TRUE(node->get_parameter("tracking_time_constant", param));
+    ASSERT_EQ(param.get_value<double>(), TRK_TC);
 
-  ASSERT_TRUE(node->get_parameter("saturation", param));
-  ASSERT_EQ(param.get_value<bool>(), SATURATION);
+    ASSERT_TRUE(node->get_parameter("saturation", param));
+    ASSERT_EQ(param.get_value<bool>(), SATURATION);
 
-  ASSERT_TRUE(node->get_parameter("antiwindup", param));
-  ASSERT_EQ(param.get_value<bool>(), ANTIWINDUP);
+    ASSERT_TRUE(node->get_parameter("antiwindup", param));
+    ASSERT_EQ(param.get_value<bool>(), ANTIWINDUP);
 
-  ASSERT_TRUE(node->get_parameter("antiwindup_strategy", param));
-  ASSERT_EQ(param.get_value<std::string>(), ANTIWINDUP_STRAT.to_string());
+    ASSERT_TRUE(node->get_parameter("antiwindup_strategy", param));
+    ASSERT_EQ(param.get_value<std::string>(), ANTIWINDUP_STRAT.to_string());
 
-  ASSERT_TRUE(node->get_parameter("save_i_term", param));
-  ASSERT_EQ(param.get_value<bool>(), false);
+    ASSERT_TRUE(node->get_parameter("save_i_term", param));
+    ASSERT_EQ(param.get_value<bool>(), false);
+  }
+  {
+    rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("pid_parameters_test");
+
+    TestablePidROS pid(node);
+
+    const double P = 1.0;
+    const double I = 2.0;
+    const double D = 3.0;
+    const double I_MAX = 10.0;
+    const double I_MIN = -10.0;
+    const double U_MAX = std::numeric_limits<double>::infinity();
+    const double U_MIN = -std::numeric_limits<double>::infinity();
+    const double TRK_TC = 4.0;
+    const bool SATURATION = false;
+    const bool ANTIWINDUP = true;
+    const AntiwindupStrategy ANTIWINDUP_STRAT = AntiwindupStrategy::NONE;
+
+    pid.initialize_from_args(
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, AntiwindupStrategy::NONE, false);
+    pid.set_gains(P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT);
+
+    rclcpp::Parameter param;
+
+    ASSERT_TRUE(node->get_parameter("p", param));
+    ASSERT_EQ(param.get_value<double>(), P);
+
+    ASSERT_TRUE(node->get_parameter("i", param));
+    ASSERT_EQ(param.get_value<double>(), I);
+
+    ASSERT_TRUE(node->get_parameter("d", param));
+    ASSERT_EQ(param.get_value<double>(), D);
+
+    ASSERT_TRUE(node->get_parameter("i_clamp_max", param));
+    ASSERT_EQ(param.get_value<double>(), I_MAX);
+
+    ASSERT_TRUE(node->get_parameter("i_clamp_min", param));
+    ASSERT_EQ(param.get_value<double>(), I_MIN);
+
+    ASSERT_TRUE(node->get_parameter("u_clamp_max", param));
+    ASSERT_EQ(param.get_value<double>(), U_MAX);
+
+    ASSERT_TRUE(node->get_parameter("u_clamp_min", param));
+    ASSERT_EQ(param.get_value<double>(), U_MIN);
+
+    ASSERT_TRUE(node->get_parameter("tracking_time_constant", param));
+    ASSERT_EQ(param.get_value<double>(), TRK_TC);
+
+    ASSERT_TRUE(node->get_parameter("saturation", param));
+    ASSERT_EQ(param.get_value<bool>(), SATURATION);
+
+    ASSERT_TRUE(node->get_parameter("antiwindup", param));
+    ASSERT_EQ(param.get_value<bool>(), ANTIWINDUP);
+
+    ASSERT_TRUE(node->get_parameter("antiwindup_strategy", param));
+    ASSERT_EQ(param.get_value<std::string>(), ANTIWINDUP_STRAT.to_string());
+
+    ASSERT_TRUE(node->get_parameter("save_i_term", param));
+    ASSERT_EQ(param.get_value<bool>(), false);
+  }
 }
 
 TEST(PidParametersTest, GetParametersFromParams)

--- a/control_toolbox/test/pid_ros_parameters_tests.cpp
+++ b/control_toolbox/test/pid_ros_parameters_tests.cpp
@@ -67,8 +67,7 @@ void check_set_parameters(
   const bool SAVE_I_TERM = true;
 
   ASSERT_NO_THROW(pid.initialize_from_args(
-    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, SATURATION, ANTIWINDUP, ANTIWINDUP_STRAT,
-    SAVE_I_TERM));
+    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT, SAVE_I_TERM));
 
   rclcpp::Parameter param;
 
@@ -152,8 +151,8 @@ TEST(PidParametersTest, InitPidTestBadParameter)
   const double TRK_TC = 4.0;
 
   ASSERT_NO_THROW(pid.initialize_from_args(
-    P, I, D, I_MAX_BAD, I_MIN_BAD, U_MAX_BAD, U_MIN_BAD, TRK_TC, false, false,
-    AntiwindupStrategy::NONE, false));
+    P, I, D, I_MAX_BAD, I_MIN_BAD, U_MAX_BAD, U_MIN_BAD, TRK_TC, false, AntiwindupStrategy::NONE,
+    false));
 
   rclcpp::Parameter param;
 
@@ -271,8 +270,7 @@ TEST(PidParametersTest, SetParametersTest)
   const bool SAVE_I_TERM = false;
 
   pid.initialize_from_args(
-    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, SATURATION, ANTIWINDUP, ANTIWINDUP_STRAT,
-    SAVE_I_TERM);
+    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT, SAVE_I_TERM);
 
   rcl_interfaces::msg::SetParametersResult set_result;
 
@@ -344,12 +342,12 @@ TEST(PidParametersTest, SetBadParametersTest)
   const double U_MAX_BAD = -20.0;
   const double U_MIN_BAD = 20.0;
   const double TRK_TC = 4.0;
-  const bool SATURATION = true;
+  const bool SATURATION = false;
   const bool ANTIWINDUP = true;
   const AntiwindupStrategy ANTIWINDUP_STRAT = AntiwindupStrategy::NONE;
 
   pid.initialize_from_args(
-    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, SATURATION, ANTIWINDUP, ANTIWINDUP_STRAT, false);
+    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT, false);
 
   rcl_interfaces::msg::SetParametersResult set_result;
 
@@ -396,7 +394,7 @@ TEST(PidParametersTest, SetBadParametersTest)
   ASSERT_EQ(gains.u_max_, U_MAX);
   ASSERT_EQ(gains.u_min_, U_MIN);
   ASSERT_EQ(gains.trk_tc_, TRK_TC);
-  ASSERT_TRUE(gains.saturation_);
+  ASSERT_FALSE(gains.saturation_);
   ASSERT_EQ(gains.antiwindup_, ANTIWINDUP);
   ASSERT_EQ(gains.antiwindup_strat_, AntiwindupStrategy::NONE);
 }
@@ -421,7 +419,7 @@ TEST(PidParametersTest, GetParametersTest)
     const AntiwindupStrategy ANTIWINDUP_STRAT = AntiwindupStrategy::NONE;
 
     pid.initialize_from_args(
-      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, AntiwindupStrategy::NONE, false);
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, AntiwindupStrategy::NONE, false);
     std::cout << "Setting gains with set_gains()" << std::endl;
     pid.set_gains(P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT);
 
@@ -481,7 +479,7 @@ TEST(PidParametersTest, GetParametersTest)
     const AntiwindupStrategy ANTIWINDUP_STRAT = AntiwindupStrategy::NONE;
 
     pid.initialize_from_args(
-      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, AntiwindupStrategy::NONE, false);
+      0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, AntiwindupStrategy::NONE, false);
     pid.set_gains(P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT);
 
     rclcpp::Parameter param;
@@ -582,9 +580,9 @@ TEST(PidParametersTest, MultiplePidInstances)
   const double TRK_TC = 4.0;
 
   ASSERT_NO_THROW(pid_1.initialize_from_args(
-    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, false, false, AntiwindupStrategy::NONE, false));
+    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, false, AntiwindupStrategy::NONE, false));
   ASSERT_NO_THROW(pid_2.initialize_from_args(
-    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, true, true, AntiwindupStrategy::NONE, false));
+    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, true, AntiwindupStrategy::NONE, false));
 
   rclcpp::Parameter param_1, param_2;
   ASSERT_TRUE(node->get_parameter("PID_1.p", param_1));

--- a/control_toolbox/test/pid_ros_parameters_tests.cpp
+++ b/control_toolbox/test/pid_ros_parameters_tests.cpp
@@ -421,8 +421,7 @@ TEST(PidParametersTest, GetParametersTest)
 
   pid.initialize_from_args(
     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, AntiwindupStrategy::NONE, false);
-  pid.set_gains(
-    P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, SATURATION, ANTIWINDUP, ANTIWINDUP_STRAT);
+  pid.set_gains(P, I, D, I_MAX, I_MIN, U_MAX, U_MIN, TRK_TC, ANTIWINDUP, ANTIWINDUP_STRAT);
 
   rclcpp::Parameter param;
 

--- a/control_toolbox/test/pid_ros_publisher_tests.cpp
+++ b/control_toolbox/test/pid_ros_publisher_tests.cpp
@@ -44,7 +44,7 @@ TEST(PidPublisherTest, PublishTest)
   control_toolbox::PidROS pid_ros = control_toolbox::PidROS(node);
 
   pid_ros.initialize_from_args(
-    1.0, 1.0, 1.0, 5.0, -5.0, 5.0, -5.0, 1.0, false, false, AntiwindupStrategy::NONE, false);
+    1.0, 1.0, 1.0, 5.0, -5.0, 5.0, -5.0, 1.0, false, AntiwindupStrategy::NONE, false);
 
   bool callback_called = false;
   control_msgs::msg::PidState::SharedPtr last_state_msg;
@@ -82,7 +82,7 @@ TEST(PidPublisherTest, PublishTestLifecycle)
       pid_ros.get_pid_state_publisher());
 
   pid_ros.initialize_from_args(
-    1.0, 1.0, 1.0, 5.0, -5.0, 5.0, -5.0, 1.0, false, false, AntiwindupStrategy::NONE, false);
+    1.0, 1.0, 1.0, 5.0, -5.0, 5.0, -5.0, 1.0, false, AntiwindupStrategy::NONE, false);
 
   bool callback_called = false;
   control_msgs::msg::PidState::SharedPtr last_state_msg;

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -437,12 +437,12 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   // Test return values  -------------------------------------------------
   double p_gain_return, i_gain_return, d_gain_return, i_max_return, i_min_return, u_max_return,
     u_min_return, trk_tc_return;
-  bool saturation_return, antiwindup_return;
+  bool antiwindup_return;
   AntiwindupStrategy antiwindup_strat_return;
 
   pid1.get_gains(
     p_gain_return, i_gain_return, d_gain_return, i_max_return, i_min_return, u_max_return,
-    u_min_return, trk_tc_return, saturation_return, antiwindup_return, antiwindup_strat_return);
+    u_min_return, trk_tc_return, antiwindup_return, antiwindup_strat_return);
 
   EXPECT_EQ(p_gain, p_gain_return);
   EXPECT_EQ(i_gain, i_gain_return);
@@ -452,7 +452,6 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, u_max_return);
   EXPECT_EQ(u_min, u_min_return);
   EXPECT_EQ(trk_tc, trk_tc_return);
-  EXPECT_EQ(false, saturation_return);
   EXPECT_EQ(antiwindup, antiwindup_return);
   EXPECT_EQ(antiwindup_strat, antiwindup_strat_return);
 
@@ -482,7 +481,6 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, g1.u_max_);
   EXPECT_EQ(u_min, g1.u_min_);
   EXPECT_EQ(trk_tc, g1.trk_tc_);
-  EXPECT_EQ(false, g1.saturation_);
   EXPECT_EQ(antiwindup, g1.antiwindup_);
   EXPECT_EQ(antiwindup_strat, g1.antiwindup_strat_);
 
@@ -495,7 +493,7 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
 
   pid2.get_gains(
     p_gain_return, i_gain_return, d_gain_return, i_max_return, i_min_return, u_max_return,
-    u_min_return, trk_tc_return, saturation_return, antiwindup_return, antiwindup_strat_return);
+    u_min_return, trk_tc_return, antiwindup_return, antiwindup_strat_return);
 
   EXPECT_EQ(p_gain, g1.p_gain_);
   EXPECT_EQ(i_gain, g1.i_gain_);
@@ -505,7 +503,6 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, g1.u_max_);
   EXPECT_EQ(u_min, g1.u_min_);
   EXPECT_EQ(trk_tc, g1.trk_tc_);
-  EXPECT_EQ(false, g1.saturation_);
   EXPECT_EQ(antiwindup, g1.antiwindup_);
   EXPECT_EQ(antiwindup_strat, g1.antiwindup_strat_);
 
@@ -522,7 +519,7 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
 
   pid3.get_gains(
     p_gain_return, i_gain_return, d_gain_return, i_max_return, i_min_return, u_max_return,
-    u_min_return, trk_tc_return, saturation_return, antiwindup_return, antiwindup_strat_return);
+    u_min_return, trk_tc_return, antiwindup_return, antiwindup_strat_return);
 
   EXPECT_EQ(p_gain, g1.p_gain_);
   EXPECT_EQ(i_gain, g1.i_gain_);
@@ -532,7 +529,6 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, g1.u_max_);
   EXPECT_EQ(u_min, g1.u_min_);
   EXPECT_EQ(trk_tc, g1.trk_tc_);
-  EXPECT_EQ(false, g1.saturation_);
   EXPECT_EQ(antiwindup, g1.antiwindup_);
   EXPECT_EQ(antiwindup_strat, g1.antiwindup_strat_);
 
@@ -726,7 +722,7 @@ TEST(CommandTest, backCalculationPIDTest)
     "back calculation technique.");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
   Pid pid(0.0, 1.0, 0.0, 0.0, 0.0, 5.0, -5.0, 1.0, false, AntiwindupStrategy::BACK_CALCULATION);
 
   double cmd = 0.0;

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -85,6 +85,7 @@ TEST(ParameterTest, outputClampTest)
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
   // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  // Setting u_max = 1.0 and u_min = -1.0 to test clamping
   Pid pid(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, false, AntiwindupStrategy::BACK_CALCULATION);
 
   double cmd = 0.0;
@@ -137,7 +138,10 @@ TEST(ParameterTest, noOutputClampTest)
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
   // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
-  Pid pid(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, false, AntiwindupStrategy::BACK_CALCULATION);
+  // Setting u_max = INF and u_min = -INF to disable clamping
+  Pid pid(
+    1.0, 0.0, 0.0, 0.0, 0.0, std::numeric_limits<double>::infinity(),
+    -std::numeric_limits<double>::infinity(), 0.0, false, AntiwindupStrategy::BACK_CALCULATION);
 
   double cmd = 0.0;
 

--- a/control_toolbox/test/pid_tests.cpp
+++ b/control_toolbox/test/pid_tests.cpp
@@ -52,9 +52,9 @@ TEST(ParameterTest, UTermBadIBoundsTestConstructor)
     "This test checks if an error is thrown for bad u_bounds specification (i.e. u_min > u_max).");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
   EXPECT_THROW(
-    Pid pid(1.0, 1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 0.0, false, false, AntiwindupStrategy::NONE),
+    Pid pid(1.0, 1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 0.0, false, AntiwindupStrategy::NONE),
     std::invalid_argument);
 }
 
@@ -65,14 +65,14 @@ TEST(ParameterTest, UTermBadIBoundsTest)
     "This test checks if gains remain for bad u_bounds specification (i.e. u_min > u_max).");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
-  Pid pid(1.0, 1.0, 1.0, 1.0, -1.0, 1.0, -1.0, 0.0, false, false, AntiwindupStrategy::NONE);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  Pid pid(1.0, 1.0, 1.0, 1.0, -1.0, 1.0, -1.0, 0.0, false, AntiwindupStrategy::NONE);
   auto gains = pid.get_gains();
   EXPECT_DOUBLE_EQ(gains.u_max_, 1.0);
   EXPECT_DOUBLE_EQ(gains.u_min_, -1.0);
   // Try to set bad u-bounds, i.e. u_min > u_max
-  EXPECT_NO_THROW(pid.set_gains(
-    1.0, 1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 0.0, false, false, AntiwindupStrategy::NONE));
+  EXPECT_NO_THROW(
+    pid.set_gains(1.0, 1.0, 1.0, 1.0, -1.0, -1.0, 1.0, 0.0, false, AntiwindupStrategy::NONE));
   // Check if gains were not updated because u-bounds are bad, i.e. u_min > u_max
   EXPECT_DOUBLE_EQ(gains.u_max_, 1.0);
   EXPECT_DOUBLE_EQ(gains.u_min_, -1.0);
@@ -84,9 +84,8 @@ TEST(ParameterTest, outputClampTest)
     "description", "This test succeeds if the output is clamped when the saturation is active.");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
-  Pid pid(
-    1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, true, false, AntiwindupStrategy::BACK_CALCULATION);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  Pid pid(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, false, AntiwindupStrategy::BACK_CALCULATION);
 
   double cmd = 0.0;
 
@@ -137,9 +136,8 @@ TEST(ParameterTest, noOutputClampTest)
     "description", "This test succeeds if the output isn't clamped when the saturation is false.");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
-  Pid pid(
-    1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, false, false, AntiwindupStrategy::BACK_CALCULATION);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  Pid pid(1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0, false, AntiwindupStrategy::BACK_CALCULATION);
 
   double cmd = 0.0;
 
@@ -192,9 +190,8 @@ TEST(ParameterTest, integrationBackCalculationZeroGainTest)
     "the back calculation technique.");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
-  Pid pid(
-    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false, AntiwindupStrategy::BACK_CALCULATION);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  Pid pid(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, AntiwindupStrategy::BACK_CALCULATION);
 
   double cmd = 0.0;
   double pe, ie, de;
@@ -240,10 +237,9 @@ TEST(ParameterTest, integrationConditionalIntegrationZeroGainTest)
     "the conditional integration technique.");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
   Pid pid(
-    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, false,
-    AntiwindupStrategy::CONDITIONAL_INTEGRATION);
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, false, AntiwindupStrategy::CONDITIONAL_INTEGRATION);
 
   double cmd = 0.0;
   double pe, ie, de;
@@ -424,17 +420,15 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   double d_gain = std::rand() % 100;
   double i_max = std::rand() % 100;
   double i_min = -1 * std::rand() % 100;
-  double u_max = std::rand() % 100;
-  double u_min = -1 * std::rand() % 100;
+  double u_max = std::numeric_limits<double>::infinity();
+  double u_min = -1 * u_max;
   double trk_tc = std::rand() % 100;
-  bool saturation = false;
   bool antiwindup = false;
   AntiwindupStrategy antiwindup_strat = AntiwindupStrategy::NONE;
 
   // Initialize the default way
   Pid pid1(
-    p_gain, i_gain, d_gain, i_max, i_min, u_max, u_min, trk_tc, saturation, antiwindup,
-    antiwindup_strat);
+    p_gain, i_gain, d_gain, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 
   // Test return values  -------------------------------------------------
   double p_gain_return, i_gain_return, d_gain_return, i_max_return, i_min_return, u_max_return,
@@ -454,7 +448,7 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, u_max_return);
   EXPECT_EQ(u_min, u_min_return);
   EXPECT_EQ(trk_tc, trk_tc_return);
-  EXPECT_EQ(saturation, saturation_return);
+  EXPECT_EQ(false, saturation_return);
   EXPECT_EQ(antiwindup, antiwindup_return);
   EXPECT_EQ(antiwindup_strat, antiwindup_strat_return);
 
@@ -466,16 +460,14 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   d_gain = std::rand() % 100;
   i_max = std::rand() % 100;
   i_min = -1 * std::rand() % 100;
-  u_max = std::rand() % 100;
-  u_min = -1 * std::rand() % 100;
+  u_max = std::numeric_limits<double>::infinity();
+  u_min = -1 * u_max;
   trk_tc = std::rand() % 100;
-  saturation = false;
   antiwindup = false;
   antiwindup_strat = AntiwindupStrategy::NONE;
 
   pid1.set_gains(
-    p_gain, i_gain, d_gain, i_max, i_min, u_max, u_min, trk_tc, saturation, antiwindup,
-    antiwindup_strat);
+    p_gain, i_gain, d_gain, i_max, i_min, u_max, u_min, trk_tc, antiwindup, antiwindup_strat);
 
   Pid::Gains g1 = pid1.get_gains();
   EXPECT_EQ(p_gain, g1.p_gain_);
@@ -486,7 +478,7 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, g1.u_max_);
   EXPECT_EQ(u_min, g1.u_min_);
   EXPECT_EQ(trk_tc, g1.trk_tc_);
-  EXPECT_EQ(saturation, g1.saturation_);
+  EXPECT_EQ(false, g1.saturation_);
   EXPECT_EQ(antiwindup, g1.antiwindup_);
   EXPECT_EQ(antiwindup_strat, g1.antiwindup_strat_);
 
@@ -509,7 +501,7 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, g1.u_max_);
   EXPECT_EQ(u_min, g1.u_min_);
   EXPECT_EQ(trk_tc, g1.trk_tc_);
-  EXPECT_EQ(saturation, g1.saturation_);
+  EXPECT_EQ(false, g1.saturation_);
   EXPECT_EQ(antiwindup, g1.antiwindup_);
   EXPECT_EQ(antiwindup_strat, g1.antiwindup_strat_);
 
@@ -536,7 +528,7 @@ TEST(ParameterTest, gainSettingCopyPIDTest)
   EXPECT_EQ(u_max, g1.u_max_);
   EXPECT_EQ(u_min, g1.u_min_);
   EXPECT_EQ(trk_tc, g1.trk_tc_);
-  EXPECT_EQ(saturation, g1.saturation_);
+  EXPECT_EQ(false, g1.saturation_);
   EXPECT_EQ(antiwindup, g1.antiwindup_);
   EXPECT_EQ(antiwindup_strat, g1.antiwindup_strat_);
 
@@ -731,8 +723,7 @@ TEST(CommandTest, backCalculationPIDTest)
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
   // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
-  Pid pid(
-    0.0, 1.0, 0.0, 0.0, 0.0, 5.0, -5.0, 1.0, true, false, AntiwindupStrategy::BACK_CALCULATION);
+  Pid pid(0.0, 1.0, 0.0, 0.0, 0.0, 5.0, -5.0, 1.0, false, AntiwindupStrategy::BACK_CALCULATION);
 
   double cmd = 0.0;
   double pe, ie, de;
@@ -788,10 +779,9 @@ TEST(CommandTest, conditionalIntegrationPIDTest)
     "conditional integration technique.");
 
   // Pid(double p, double i, double d, double i_max, double i_min, double u_max, double u_min,
-  // double trk_tc, bool saturation, bool antiwindup, AntiwindupStrategy antiwindup_strat);
+  // double trk_tc, bool antiwindup, AntiwindupStrategy antiwindup_strat);
   Pid pid(
-    0.0, 1.0, 0.0, 0.0, 0.0, 5.0, -5.0, 1.0, true, false,
-    AntiwindupStrategy::CONDITIONAL_INTEGRATION);
+    0.0, 1.0, 0.0, 0.0, 0.0, 5.0, -5.0, 1.0, false, AntiwindupStrategy::CONDITIONAL_INTEGRATION);
 
   double cmd = 0.0;
   double pe, ie, de;


### PR DESCRIPTION
This PR consists of changes to cleanup the saturation boolean of the PID toolbox