### PR TITLE
Don't validate data_out if it is empty

### DIFF
--- a/control_toolbox/CMakeLists.txt
+++ b/control_toolbox/CMakeLists.txt
@@ -46,6 +46,7 @@ target_include_directories(control_toolbox PUBLIC
 target_link_libraries(control_toolbox PUBLIC
   ${control_msgs_TARGETS}
   ${rcl_interfaces_TARGETS}
+  fmt::fmt
   rclcpp::rclcpp
   rcutils::rcutils
   realtime_tools::realtime_tools

--- a/control_toolbox/package.xml
+++ b/control_toolbox/package.xml
@@ -22,6 +22,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>ros2_control_cmake</build_depend>
+  <build_depend>fmt</build_depend>
 
   <depend>control_msgs</depend>
   <depend>eigen</depend>


### PR DESCRIPTION
https://github.com/ros-controls/ros2_controllers/pull/560 fails because filter_chains does not initialize intermediate output variables, which makes the assertion `data_in.header.frame_id == data_out.header.frame_id` fail.

I also changed the assertions to throwing exceptions, using fmt to concatenate numbers and strings.