### PR TITLE
Skip callback if saturation parameter is not declared

### DIFF
--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -566,7 +566,25 @@ void PidROS::set_parameter_event_callback()
     // The saturation parameter is special, it can change the u_min and u_max parameters
     // so we need to check it first and then proceed with the loop, as if we update only one
     // parameter, we need to keep this logic up-to-date. So, do not move it inside the loop
-    bool saturation = node_params_->get_parameter(param_prefix_ + "saturation").get_value<bool>();
+    bool saturation = true;  // default value
+    try
+    {
+      if (!node_params_->has_parameter(param_prefix_ + "saturation"))
+      {
+        RCLCPP_WARN(node_logging_->get_logger(), "Saturation parameter is not declared, skipping.");
+        return result;
+      }
+      else
+      {
+        saturation = node_params_->get_parameter(param_prefix_ + "saturation").get_value<bool>();
+      }
+    }
+    catch (const std::exception & e)
+    {
+      RCLCPP_ERROR_STREAM(
+        node_logging_->get_logger(), "Error with saturation parameter: " << e.what());
+    }
+
     std::for_each(
       parameters.begin(), parameters.end(),
       [&, this](const rclcpp::Parameter & parameter)

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -569,12 +569,8 @@ void PidROS::set_parameter_event_callback()
     bool saturation = true;  // default value
     try
     {
-      if (!node_params_->has_parameter(param_prefix_ + "saturation"))
-      {
-        RCLCPP_WARN(node_logging_->get_logger(), "Saturation parameter is not declared, skipping.");
-        return result;
-      }
-      else
+      // we can't use get_parameter_or, because we don't have access to a rclcpp::Node
+      if (node_params_->has_parameter(param_prefix_ + "saturation"))
       {
         saturation = node_params_->get_parameter(param_prefix_ + "saturation").get_value<bool>();
       }


### PR DESCRIPTION
I'm not sure why the callback is executed before the parameter is declared. How should we fix this? just skip it, or auto-declare?

Fixes https://github.com/ros-controls/ros2_control_ci/issues/364
Fixes https://github.com/ros-controls/ros2_control_ci/issues/365
Fixes https://github.com/ros-controls/ros2_control_ci/issues/366
Fixes https://github.com/ros-controls/ros2_control_ci/issues/367
Fixes https://github.com/ros-controls/ros2_control_ci/issues/368
Fixes https://github.com/ros-controls/ros2_control_ci/issues/369
Fixes https://github.com/ros-controls/ros2_control_ci/issues/370
Fixes https://github.com/ros-controls/ros2_controllers/issues/1754
