### PR TITLE
Deprecate `prefix_is_for_params` of PidROS

### DIFF
--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -40,7 +40,6 @@
 
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
-#include "rclcpp/logging.hpp"  // TODO(christophfroehlich) remove after deprecation removal
 #include "rclcpp/node.hpp"
 
 #include "realtime_tools/realtime_buffer.hpp"
@@ -77,11 +76,6 @@ public:
       node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(), prefix,
       prefix_is_for_params)
   {
-    // note: deprecation on templated constructor does not show up
-    RCLCPP_INFO(
-      node_ptr->get_logger(),
-      "PidROS constructor with node and prefix is deprecated, use overloads with explicit "
-      "prefixes for params and topics");
   }
   template <class NodeT>
   explicit PidROS(std::shared_ptr<NodeT> node_ptr, const std::string & param_prefix)

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -85,6 +85,17 @@ public:
       param_prefix, std::string(""), false)
   {
   }
+  /*!
+   * \brief Constructor of PidROS class.
+   *
+   * The node is passed to this class to handler the ROS parameters, this class allows
+   * to add a prefix to the pid parameters
+   *
+   * \param node Any ROS node
+   * \param param_prefix prefix to add to the pid parameters. This string is not manipulated, i.e., probably should end with `.`
+   * \param topic_prefix prefix to add to the state publisher. This string is not manipulated, i.e., probably should end with `/`. If it starts with `~/`, topic will be local under the namespace of the node. If it starts with `/` or an alphanumeric character, topic will be in global namespace.
+   *
+   */
   template <class NodeT>
   explicit PidROS(
     std::shared_ptr<NodeT> node_ptr, std::string param_prefix, std::string topic_prefix)
@@ -94,6 +105,18 @@ public:
       param_prefix, topic_prefix, true)
   {
   }
+  /*!
+   * \brief Constructor of PidROS class.
+   *
+   * The node is passed to this class to handler the ROS parameters, this class allows
+   * to add a prefix to the pid parameters
+   *
+   * \param node Any ROS node
+   * \param param_prefix prefix to add to the pid parameters. This string is not manipulated, i.e., probably should end with `.`
+   * \param topic_prefix prefix to add to the state publisher. This string is not manipulated, i.e., probably should end with `/`. If it starts with `~/`, topic will be local under the namespace of the node. If it starts with `/` or an alphanumeric character, topic will be in global namespace.
+   * \param activate_state_publisher If true, the publisher will be enabled after initialization.
+   *
+   */
   template <class NodeT>
   explicit PidROS(
     std::shared_ptr<NodeT> node_ptr, std::string param_prefix, std::string topic_prefix,
@@ -112,6 +135,17 @@ public:
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
     std::string prefix = std::string(""), bool prefix_is_for_params = false);
 
+  /*!
+   * \brief Constructor of PidROS class with node_interfaces
+   *
+   * \param node_base Node base interface pointer.
+   * \param node_logging Node logging interface pointer.
+   * \param node_params Node parameters interface pointer.
+   * \param topics_interface Node topics interface pointer.
+   * \param param_prefix Prefix to add to the PID parameters. This string is not manipulated, i.e., probably should end with `.`.
+   * \param topic_prefix Prefix to add to the state publisher. This string is not manipulated, i.e., probably should end with `/`. If it starts with `~/`, topic will be local under the namespace of the node. If it starts with `/` or an alphanumeric character, topic will be in global namespace.
+   * \param activate_state_publisher If true, the publisher will be enabled after initialization.
+   */
   PidROS(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -98,7 +98,8 @@ public:
    */
   template <class NodeT>
   explicit PidROS(
-    std::shared_ptr<NodeT> node_ptr, const std::string &param_prefix, const std::string &topic_prefix)
+    std::shared_ptr<NodeT> node_ptr, const std::string & param_prefix,
+    const std::string & topic_prefix)
   : PidROS(
       node_ptr->get_node_base_interface(), node_ptr->get_node_logging_interface(),
       node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(),
@@ -151,7 +152,8 @@ public:
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params,
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
-    const std::string &param_prefix, const std::string &topic_prefix, bool activate_state_publisher);
+    const std::string & param_prefix, const std::string & topic_prefix,
+    bool activate_state_publisher);
 
   /*!
    * \brief Initialize the PID controller and set the parameters

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -68,7 +68,7 @@ public:
    *
    */
   template <class NodeT>
-  explicit PidROS(
+  [[deprecated("Use overloads with explicit prefixes for params and topics")]] explicit PidROS(
     std::shared_ptr<NodeT> node_ptr, std::string prefix = std::string(""),
     bool prefix_is_for_params = false)
   : PidROS(
@@ -77,13 +77,47 @@ public:
       prefix_is_for_params)
   {
   }
+  template <class NodeT>
+  explicit PidROS(std::shared_ptr<NodeT> node_ptr, std::string param_prefix = std::string(""))
+  : PidROS(
+      node_ptr->get_node_base_interface(), node_ptr->get_node_logging_interface(),
+      node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(),
+      param_prefix, std::string(""), false)
+  {
+  }
+  template <class NodeT>
+  explicit PidROS(
+    std::shared_ptr<NodeT> node_ptr, std::string param_prefix, std::string topic_prefix)
+  : PidROS(
+      node_ptr->get_node_base_interface(), node_ptr->get_node_logging_interface(),
+      node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(),
+      param_prefix, topic_prefix, true)
+  {
+  }
+  template <class NodeT>
+  explicit PidROS(
+    std::shared_ptr<NodeT> node_ptr, std::string param_prefix, std::string topic_prefix,
+    bool activate_state_publisher)
+  : PidROS(
+      node_ptr->get_node_base_interface(), node_ptr->get_node_logging_interface(),
+      node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(),
+      param_prefix, topic_prefix, activate_state_publisher)
+  {
+  }
+
+  [[deprecated("Use overloads with explicit prefixes for params and topics")]] PidROS(
+    rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
+    std::string prefix = std::string(""), bool prefix_is_for_params = false);
 
   PidROS(
     rclcpp::node_interfaces::NodeBaseInterface::SharedPtr node_base,
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params,
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
-    std::string prefix = std::string(""), bool prefix_is_for_params = false);
+    std::string param_prefix, std::string topic_prefix, bool activate_state_publisher);
 
   /*!
    * \brief Initialize the PID controller and set the parameters
@@ -312,7 +346,7 @@ private:
    *               If not stated explicitly using "/" or "~", prefix is interpreted as global, i.e.,
    *               "/" will be added in front of topic prefix
    */
-  void set_prefixes(const std::string & topic_prefix);
+  [[deprecated]] void set_prefixes(const std::string & topic_prefix);
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr parameter_callback_;
 

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -92,8 +92,8 @@ public:
    * to add a prefix to the pid parameters
    *
    * \param node Any ROS node
-   * \param param_prefix prefix to add to the pid parameters. This string is not manipulated, i.e., probably should end with `.`
-   * \param topic_prefix prefix to add to the state publisher. This string is not manipulated, i.e., probably should end with `/`. If it starts with `~/`, topic will be local under the namespace of the node. If it starts with `/` or an alphanumeric character, topic will be in global namespace.
+   * \param param_prefix prefix to add to the pid parameters.
+   * \param topic_prefix prefix to add to the state publisher. If it starts with `~/`, topic will be local under the namespace of the node. If it starts with `/` or an alphanumeric character, topic will be in global namespace.
    *
    */
   template <class NodeT>
@@ -113,8 +113,8 @@ public:
    * to add a prefix to the pid parameters
    *
    * \param node Any ROS node
-   * \param param_prefix prefix to add to the pid parameters. This string is not manipulated, i.e., probably should end with `.`
-   * \param topic_prefix prefix to add to the state publisher. This string is not manipulated, i.e., probably should end with `/`. If it starts with `~/`, topic will be local under the namespace of the node. If it starts with `/` or an alphanumeric character, topic will be in global namespace.
+   * \param param_prefix prefix to add to the pid parameters.
+   * \param topic_prefix prefix to add to the state publisher. If it starts with `~/`, topic will be local under the namespace of the node. If it starts with `/` or an alphanumeric character, topic will be in global namespace.
    * \param activate_state_publisher If true, the publisher will be enabled after initialization.
    *
    */

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -78,11 +78,11 @@ public:
   {
   }
   template <class NodeT>
-  explicit PidROS(std::shared_ptr<NodeT> node_ptr, std::string param_prefix = std::string(""))
+  explicit PidROS(std::shared_ptr<NodeT> node_ptr, const std::string & param_prefix)
   : PidROS(
       node_ptr->get_node_base_interface(), node_ptr->get_node_logging_interface(),
       node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(),
-      param_prefix, std::string(""), false)
+      param_prefix, "", false)
   {
   }
   /*!
@@ -98,7 +98,7 @@ public:
    */
   template <class NodeT>
   explicit PidROS(
-    std::shared_ptr<NodeT> node_ptr, std::string param_prefix, std::string topic_prefix)
+    std::shared_ptr<NodeT> node_ptr, const std::string &param_prefix, const std::string &topic_prefix)
   : PidROS(
       node_ptr->get_node_base_interface(), node_ptr->get_node_logging_interface(),
       node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(),
@@ -151,7 +151,7 @@ public:
     rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
     rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params,
     rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
-    std::string param_prefix, std::string topic_prefix, bool activate_state_publisher);
+    const std::string &param_prefix, const std::string &topic_prefix, bool activate_state_publisher);
 
   /*!
    * \brief Initialize the PID controller and set the parameters

--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -40,6 +40,7 @@
 
 #include "rclcpp/clock.hpp"
 #include "rclcpp/duration.hpp"
+#include "rclcpp/logging.hpp"  // TODO(christophfroehlich) remove after deprecation removal
 #include "rclcpp/node.hpp"
 
 #include "realtime_tools/realtime_buffer.hpp"
@@ -76,6 +77,11 @@ public:
       node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(), prefix,
       prefix_is_for_params)
   {
+    // note: deprecation on templated constructor does not show up
+    RCLCPP_INFO(
+      node_ptr->get_logger(),
+      "PidROS constructor with node and prefix is deprecated, use overloads with explicit "
+      "prefixes for params and topics");
   }
   template <class NodeT>
   explicit PidROS(std::shared_ptr<NodeT> node_ptr, const std::string & param_prefix)

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -103,7 +103,7 @@ PidROS::PidROS(
   rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging,
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params,
   rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr topics_interface,
-  std::string param_prefix, std::string topic_prefix, bool activate_state_publisher)
+  const std::string & param_prefix, const std::string & topic_prefix, bool activate_state_publisher)
 : topic_prefix_(topic_prefix),
   param_prefix_(param_prefix),
   node_base_(node_base),

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -54,6 +54,12 @@ PidROS::PidROS(
   node_params_(node_params),
   topics_interface_(topics_interface)
 {
+  // note: deprecation on templated constructor does not show up
+  RCLCPP_INFO(
+    node_logging->get_logger(),
+    "PidROS constructor with node and prefix is deprecated, use overloads with explicit "
+    "prefixes for params and topics");
+
   if (prefix_is_for_params)
   {
     param_prefix_ = prefix;

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -111,6 +111,17 @@ PidROS::PidROS(
   node_params_(node_params),
   topics_interface_(topics_interface)
 {
+  // Add a trailing "."
+  if (!param_prefix_.empty() && param_prefix_.back() != '.')
+  {
+    param_prefix_.append(".");
+  }
+  // Add a trailing "/"
+  if (!topic_prefix_.empty() && topic_prefix_.back() != '/')
+  {
+    topic_prefix_.append("/");
+  }
+
   if (activate_state_publisher)
   {
     state_pub_ = rclcpp::create_publisher<control_msgs::msg::PidState>(

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -55,7 +55,7 @@ PidROS::PidROS(
   topics_interface_(topics_interface)
 {
   // note: deprecation on templated constructor does not show up
-  RCLCPP_INFO(
+  RCLCPP_WARN(
     node_logging->get_logger(),
     "PidROS constructor with node and prefix is deprecated, use overloads with explicit "
     "prefixes for params and topics");

--- a/control_toolbox/test/pid_ros_parameters_tests.cpp
+++ b/control_toolbox/test/pid_ros_parameters_tests.cpp
@@ -274,6 +274,9 @@ TEST(PidParametersTest, SetParametersTest)
   ASSERT_TRUE(set_result.successful);
   ASSERT_NO_THROW(set_result = node->set_parameter(rclcpp::Parameter("save_i_term", SAVE_I_TERM)));
   ASSERT_TRUE(set_result.successful);
+  ASSERT_NO_THROW(
+    set_result = node->set_parameter(rclcpp::Parameter("activate_state_publisher", true)));
+  ASSERT_TRUE(set_result.successful);
 
   // process callbacks
   rclcpp::spin_some(node->get_node_base_interface());
@@ -483,6 +486,37 @@ TEST(PidParametersTest, GetParametersTest)
 
     ASSERT_TRUE(node->get_parameter("save_i_term", param));
     ASSERT_EQ(param.get_value<bool>(), false);
+
+    ASSERT_TRUE(node->get_parameter("activate_state_publisher", param));
+    ASSERT_EQ(param.get_value<bool>(), false);
+  }
+  {
+    // test activate_state_publisher
+    rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("pid_parameters_test");
+
+    TestablePidROS pid(node, "", "", true);
+    const double P = 1.0;
+    const double I = 2.0;
+    const double D = 3.0;
+    const double I_MAX = 10.0;
+    const double I_MIN = -10.0;
+    const double U_MAX = 10.0;
+    const double U_MIN = -10.0;
+    const double TRK_TC = 4.0;
+    const bool ANTIWINDUP = true;
+
+    AntiWindupStrategy ANTIWINDUP_STRAT;
+    ANTIWINDUP_STRAT.type = AntiWindupStrategy::LEGACY;
+    ANTIWINDUP_STRAT.i_max = I_MAX;
+    ANTIWINDUP_STRAT.i_min = I_MIN;
+    ANTIWINDUP_STRAT.tracking_time_constant = TRK_TC;
+    ANTIWINDUP_STRAT.legacy_antiwindup = ANTIWINDUP;
+
+    ASSERT_TRUE(pid.initialize_from_args(P, I, D, U_MAX, U_MIN, ANTIWINDUP_STRAT, false));
+
+    rclcpp::Parameter param;
+    ASSERT_TRUE(node->get_parameter("activate_state_publisher", param));
+    ASSERT_EQ(param.get_value<bool>(), true);
   }
   {
     rclcpp::Node::SharedPtr node = std::make_shared<rclcpp::Node>("pid_parameters_test");

--- a/control_toolbox/test/pid_ros_publisher_tests.cpp
+++ b/control_toolbox/test/pid_ros_publisher_tests.cpp
@@ -41,7 +41,7 @@ TEST(PidPublisherTest, PublishTest)
 
   auto node = std::make_shared<rclcpp::Node>("pid_publisher_test");
 
-  control_toolbox::PidROS pid_ros = control_toolbox::PidROS(node);
+  control_toolbox::PidROS pid_ros = control_toolbox::PidROS(node, "", "", true);
 
   AntiWindupStrategy antiwindup_strat;
   antiwindup_strat.type = AntiWindupStrategy::LEGACY;
@@ -80,7 +80,7 @@ TEST(PidPublisherTest, PublishTestLifecycle)
 
   auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("pid_publisher_test");
 
-  control_toolbox::PidROS pid_ros(node);
+  control_toolbox::PidROS pid_ros(node, "", "", true);
 
   auto state_pub_lifecycle_ =
     std::dynamic_pointer_cast<rclcpp_lifecycle::LifecyclePublisher<control_msgs::msg::PidState>>(

--- a/control_toolbox/test/pid_ros_publisher_tests.cpp
+++ b/control_toolbox/test/pid_ros_publisher_tests.cpp
@@ -149,7 +149,8 @@ TEST(PidPublisherTest, PublishTest_prefix)
 
   auto node = std::make_shared<rclcpp::Node>("pid_publisher_test");
 
-  control_toolbox::PidROS pid_ros = control_toolbox::PidROS(node, "", "global/", true);
+  // test with a prefix for the topic without trailing / (should be auto-added)
+  control_toolbox::PidROS pid_ros = control_toolbox::PidROS(node, "", "global", true);
 
   AntiWindupStrategy antiwindup_strat;
   antiwindup_strat.type = AntiWindupStrategy::LEGACY;

--- a/control_toolbox/test/pid_ros_publisher_tests.cpp
+++ b/control_toolbox/test/pid_ros_publisher_tests.cpp
@@ -129,6 +129,7 @@ TEST(PidPublisherTest, PublishTest_start_deactivated)
   ASSERT_NO_THROW(
     set_result = node->set_parameter(rclcpp::Parameter("activate_state_publisher", false)));
   ASSERT_TRUE(set_result.successful);
+  rclcpp::spin_some(node);  // process callbacks to ensure that no further messages are received
   callback_called = false;
 
   // wait for callback
@@ -162,18 +163,6 @@ TEST(PidPublisherTest, PublishTest_prefix)
   control_msgs::msg::PidState::SharedPtr last_state_msg;
   auto state_callback = [&](const control_msgs::msg::PidState::SharedPtr)
   { callback_called = true; };
-
-  // List all publishers from this node
-  auto publishers_info = node->get_topic_names_and_types();
-  for (const auto & info : publishers_info)
-  {
-    std::cout << "Publisher on topic: " << info.first << " with types: ";
-    for (const auto & type : info.second)
-    {
-      std::cout << type << " ";
-    }
-    std::cout << std::endl;
-  }
 
   auto state_sub = node->create_subscription<control_msgs::msg::PidState>(
     "/global/pid_state", rclcpp::SensorDataQoS(), state_callback);
@@ -213,18 +202,6 @@ TEST(PidPublisherTest, PublishTest_local_prefix)
   control_msgs::msg::PidState::SharedPtr last_state_msg;
   auto state_callback = [&](const control_msgs::msg::PidState::SharedPtr)
   { callback_called = true; };
-
-  // List all publishers from this node
-  auto publishers_info = node->get_topic_names_and_types();
-  for (const auto & info : publishers_info)
-  {
-    std::cout << "Publisher on topic: " << info.first << " with types: ";
-    for (const auto & type : info.second)
-    {
-      std::cout << type << " ";
-    }
-    std::cout << std::endl;
-  }
 
   auto state_sub = node->create_subscription<control_msgs::msg::PidState>(
     "~/local/pid_state", rclcpp::SensorDataQoS(), state_callback);

--- a/doc/migration.rst
+++ b/doc/migration.rst
@@ -4,6 +4,7 @@ Migration Guides: Jazzy to Kilted
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This list summarizes important changes between Jazzy (previous) and Kilted (current) releases, where changes to user code might be necessary.
 
-Pid/PidRos
+Pid/PidROS
 ***********************************************************
 * The parameters ``antiwindup``, ``i_clamp_max``, and ``i_clamp_min`` have been removed. The anti-windup behavior is now configured via the ``AntiWindupStrategy`` enum. (`#298 <https://github.com/ros-controls/control_toolbox/pull/298>`_).
+* The constructors of ``PidROS`` have changed and ``prefix_is_for_params`` argument has been deprecated. Use explicit parameter and topic prefix instead (`#431 <https://github.com/ros-controls/control_toolbox/pull/431>`_).

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -4,6 +4,7 @@ Release Notes: Jazzy to Kilted
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This list summarizes the changes between Jazzy (previous) and Kilted (current) releases.
 
-Pid/PidRos
+Pid/PidROS
 ***********************************************************
 * Added a saturation feature to PID output and two anti-windup techniques (back calculation and conditional integration) (`#298 <https://github.com/ros-controls/control_toolbox/pull/298>`_).
+* Added a constructor argument to ``PidROS`` to control if the PID state publisher is initially active or not. Can be changed during runtime by using  ``activate_state_publisher`` parameter. (`#431 <https://github.com/ros-controls/control_toolbox/pull/431>`_).


### PR DESCRIPTION
See https://github.com/ros-controls/control_toolbox/issues/156#issuecomment-2985605034

Fixes #156 