### PR TITLE
[jazzy] Add missing public dependency on fmt library

### DIFF
--- a/control_toolbox/CMakeLists.txt
+++ b/control_toolbox/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   control_msgs
+  fmt
   rclcpp
   rcl_interfaces
   rcutils
@@ -46,6 +47,7 @@ target_include_directories(control_toolbox PUBLIC
 target_link_libraries(control_toolbox PUBLIC
   ${control_msgs_TARGETS}
   ${rcl_interfaces_TARGETS}
+  fmt::fmt
   rclcpp::rclcpp
   rcutils::rcutils
   realtime_tools::realtime_tools

--- a/control_toolbox/package.xml
+++ b/control_toolbox/package.xml
@@ -23,6 +23,8 @@
 
   <build_depend>ros2_control_cmake</build_depend>
 
+  <build_export_depend>fmt</build_export_depend>
+
   <depend>control_msgs</depend>
   <depend>eigen</depend>
   <depend>filters</depend>


### PR DESCRIPTION
The fmt public dependency was added in the C++ code in https://github.com/ros-controls/control_toolbox/pull/410, but without properly declaring the dependency in CMake and package.xml . The issue in the `ros2-master` branch was fixed by https://github.com/ros-controls/control_toolbox/pull/391, but that PR was not backported to the `jazzy` branch.

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
