### PR TITLE
Fix `github.ref` check for concurrency settings

### DIFF
--- a/.github/workflows/humble-abi-compatibility.yml
+++ b/.github/workflows/humble-abi-compatibility.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - humble
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   abi_check:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-abi-check.yml@master

--- a/.github/workflows/humble-binary-build.yml
+++ b/.github/workflows/humble-binary-build.yml
@@ -13,6 +13,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '28 6 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/humble-build-coverage.yml
+++ b/.github/workflows/humble-build-coverage.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - humble
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   coverage_humble:
     name: coverage build - humble

--- a/.github/workflows/humble-build-downstream.yml
+++ b/.github/workflows/humble-build-downstream.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - humble
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-downstream:

--- a/.github/workflows/humble-build-source.yml
+++ b/.github/workflows/humble-build-source.yml
@@ -8,6 +8,11 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 3 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   source_build:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master

--- a/.github/workflows/humble-ci-pre-commit.yml
+++ b/.github/workflows/humble-ci-pre-commit.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - humble
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   pre-commit:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master

--- a/.github/workflows/humble-debian-build.yml
+++ b/.github/workflows/humble-debian-build.yml
@@ -8,6 +8,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 5 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/humble-rhel-semi-binary-build.yml
+++ b/.github/workflows/humble-rhel-semi-binary-build.yml
@@ -8,6 +8,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 3 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/humble-semi-binary-build.yml
+++ b/.github/workflows/humble-semi-binary-build.yml
@@ -13,6 +13,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '28 6 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   semi-binary:

--- a/.github/workflows/jazzy-abi-compatibility.yml
+++ b/.github/workflows/jazzy-abi-compatibility.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - jazzy
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   abi_check:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-abi-check.yml@master

--- a/.github/workflows/jazzy-binary-build.yml
+++ b/.github/workflows/jazzy-binary-build.yml
@@ -13,6 +13,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '28 6 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/jazzy-build-coverage.yml
+++ b/.github/workflows/jazzy-build-coverage.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - jazzy
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   coverage:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-build-coverage.yml@master

--- a/.github/workflows/jazzy-build-downstream.yml
+++ b/.github/workflows/jazzy-build-downstream.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - jazzy
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-downstream:

--- a/.github/workflows/jazzy-build-source.yml
+++ b/.github/workflows/jazzy-build-source.yml
@@ -8,6 +8,11 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 3 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   source_build:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master

--- a/.github/workflows/jazzy-check-docs.yml
+++ b/.github/workflows/jazzy-check-docs.yml
@@ -18,8 +18,9 @@ on:
       - '.github/workflows/jazzy-check-docs.yml'
 
 concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   check-docs:

--- a/.github/workflows/jazzy-ci-pre-commit.yml
+++ b/.github/workflows/jazzy-ci-pre-commit.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - jazzy
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   pre-commit:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master

--- a/.github/workflows/jazzy-debian-build.yml
+++ b/.github/workflows/jazzy-debian-build.yml
@@ -8,6 +8,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 5 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/jazzy-rhel-semi-binary-build.yml
+++ b/.github/workflows/jazzy-rhel-semi-binary-build.yml
@@ -8,6 +8,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 3 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/jazzy-semi-binary-build.yml
+++ b/.github/workflows/jazzy-semi-binary-build.yml
@@ -13,6 +13,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '28 6 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   semi-binary:

--- a/.github/workflows/rolling-abi-compatibility.yml
+++ b/.github/workflows/rolling-abi-compatibility.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - ros2-master
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   abi_check:
     strategy:

--- a/.github/workflows/rolling-binary-build.yml
+++ b/.github/workflows/rolling-binary-build.yml
@@ -13,6 +13,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '28 6 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   binary:

--- a/.github/workflows/rolling-build-coverage.yml
+++ b/.github/workflows/rolling-build-coverage.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - ros2-master
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   coverage_rolling:
     name: coverage build - rolling

--- a/.github/workflows/rolling-build-downstream.yml
+++ b/.github/workflows/rolling-build-downstream.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - ros2-master
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build-downstream:

--- a/.github/workflows/rolling-build-source.yml
+++ b/.github/workflows/rolling-build-source.yml
@@ -8,6 +8,11 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 3 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   source_build:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-ros-tooling-source-build.yml@master

--- a/.github/workflows/rolling-check-docs.yml
+++ b/.github/workflows/rolling-check-docs.yml
@@ -18,8 +18,9 @@ on:
       - '.github/workflows/rolling-check-docs.yml'
 
 concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   check-docs:

--- a/.github/workflows/rolling-ci-pre-commit.yml
+++ b/.github/workflows/rolling-ci-pre-commit.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - ros2-master
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   pre-commit:
     uses: ros-controls/ros2_control_ci/.github/workflows/reusable-pre-commit.yml@master

--- a/.github/workflows/rolling-compatibility-build.yml
+++ b/.github/workflows/rolling-compatibility-build.yml
@@ -12,9 +12,9 @@ on:
       - ros2-master
 
 concurrency:
-  # cancel previous runs of the same workflow, except for pushes on ros2-master branch
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, '/refs/heads') }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   build:

--- a/.github/workflows/rolling-debian-build.yml
+++ b/.github/workflows/rolling-debian-build.yml
@@ -8,6 +8,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 5 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   debian_semi_binary_build:

--- a/.github/workflows/rolling-rhel-semi-binary-build.yml
+++ b/.github/workflows/rolling-rhel-semi-binary-build.yml
@@ -8,6 +8,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '03 3 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   rhel_semi_binary_build:

--- a/.github/workflows/rolling-semi-binary-build-win.yml
+++ b/.github/workflows/rolling-semi-binary-build-win.yml
@@ -16,6 +16,11 @@ on:
   #   types:
   #     - created
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
+
 jobs:
   binary-windows:
     # if: |

--- a/.github/workflows/rolling-semi-binary-build.yml
+++ b/.github/workflows/rolling-semi-binary-build.yml
@@ -13,6 +13,10 @@ on:
     # Run every day to detect flakiness and broken dependencies
     - cron: '28 6 * * MON-FRI'
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   semi-binary:

--- a/.github/workflows/rosdoc2.yml
+++ b/.github/workflows/rosdoc2.yml
@@ -8,6 +8,10 @@ on:
       - rosdoc2.yaml
       - package.xml
 
+concurrency:
+  # cancel previous runs of the same workflow, except for pushes on given branches branch
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads') }}
 
 jobs:
   check:


### PR DESCRIPTION
`github.ref`:
> The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>.

which means the leading slash was wrong, see [this canceled job for example](https://github.com/ros-controls/kinematics_interface/actions/runs/17260587722).

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

I also added the concurrency settings for all other workflows.