### PR TITLE
Fix -Wuninitialized-const-reference

### DIFF
--- a/control_toolbox/test/control_filters/test_exponential_filter.cpp
+++ b/control_toolbox/test/control_filters/test_exponential_filter.cpp
@@ -23,7 +23,7 @@ TEST_F(FilterTest, TestExponentialFilterThrowsUnconfigured)
 {
   std::shared_ptr<filters::FilterBase<double>> filter_ =
     std::make_shared<control_filters::ExponentialFilter<double>>();
-  double in, out;
+  double in = 42., out;
   ASSERT_THROW(filter_->update(in, out), std::runtime_error);
 }
 

--- a/control_toolbox/test/control_filters/test_low_pass_filter.cpp
+++ b/control_toolbox/test/control_filters/test_low_pass_filter.cpp
@@ -73,7 +73,7 @@ TEST_F(FilterTest, TestLowPassFilterThrowsUnconfigured)
 {
   std::shared_ptr<filters::FilterBase<double>> filter_ =
     std::make_shared<control_filters::LowPassFilter<double>>();
-  double in, out;
+  double in = 42., out;
   ASSERT_THROW(filter_->update(in, out), std::runtime_error);
 }
 

--- a/control_toolbox/test/control_filters/test_rate_limiter.cpp
+++ b/control_toolbox/test/control_filters/test_rate_limiter.cpp
@@ -72,7 +72,7 @@ TEST_F(FilterTest, TestRateLimiterThrowsUnconfigured)
 {
   std::shared_ptr<filters::FilterBase<double>> filter_ =
     std::make_shared<control_filters::RateLimiter<double>>();
-  double in, out;
+  double in = 42., out;
   ASSERT_THROW(filter_->update(in, out), std::runtime_error);
 }
 


### PR DESCRIPTION
```
/workspaces/ros2_rolling_ws/src/control_toolbox/control_toolbox/test/control_filters/test_rate_limiter.cpp:76:32: warning: variable 'in' is uninitialized when passed as a const reference argument here [-Wuninitialized-const-reference]
   76 |   ASSERT_THROW(filter_->update(in, out), std::runtime_error);
      |                                ^~
```
https://github.com/ros-controls/ros2_control_cmake/pull/15