### PR TITLE
Fix -Wunused-result of rcutils_logging

### DIFF
--- a/control_toolbox/test/pid_ros_parameters_tests.cpp
+++ b/control_toolbox/test/pid_ros_parameters_tests.cpp
@@ -724,7 +724,8 @@ TEST(PidParametersTest, PrintValuesLogsExpectedContent)
   };
 
   // Ensure our logger emits INFO
-  rcutils_logging_set_logger_level(kLoggerName, RCUTILS_LOG_SEVERITY_INFO);
+  ASSERT_EQ(
+    rcutils_logging_set_logger_level(kLoggerName, RCUTILS_LOG_SEVERITY_INFO), RCUTILS_RET_OK);
 
   // Swap in our capture handler
   prev_handler = rcutils_logging_get_output_handler();


### PR DESCRIPTION
```
Starting >>> control_toolbox
--- stderr: control_toolbox                              
/workspaces/ros2_jazzy_ws/src/control_toolbox/control_toolbox/test/pid_ros_parameters_tests.cpp: In member function ‘virtual void PidParametersTest_PrintValuesLogsExpectedContent_Test::TestBody()’:
/workspaces/ros2_jazzy_ws/src/control_toolbox/control_toolbox/test/pid_ros_parameters_tests.cpp:763:35: warning: ignoring return value of ‘rcutils_ret_t rcutils_logging_set_logger_level(const char*, int)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  763 |   rcutils_logging_set_logger_level(kLoggerName, RCUTILS_LOG_SEVERITY_INFO);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
---
```