### PR TITLE
Fix calculation of tracking time constant

### DIFF
--- a/control_toolbox/include/control_toolbox/pid.hpp
+++ b/control_toolbox/include/control_toolbox/pid.hpp
@@ -45,12 +45,6 @@
 
 namespace control_toolbox
 {
-template <typename T>
-inline bool is_zero(T value, T tolerance = std::numeric_limits<T>::epsilon())
-{
-  return std::abs(value) <= tolerance;
-}
-
 /**
  * \brief Antiwindup strategy for PID controllers.
  *
@@ -113,14 +107,14 @@ public:
     }
   }
 
-  void validate(const double i_gain) const
+  void validate() const
   {
     if (type == UNDEFINED)
     {
       throw std::invalid_argument("AntiWindupStrategy is UNDEFINED. Please set a valid type");
     }
     if (
-      type == BACK_CALCULATION && !is_zero(i_gain) &&
+      type == BACK_CALCULATION &&
       (tracking_time_constant < 0.0 || !std::isfinite(tracking_time_constant)))
     {
       throw std::invalid_argument(
@@ -173,6 +167,12 @@ public:
   double error_deadband =
     std::numeric_limits<double>::epsilon(); /**< Error deadband to avoid integration. */
 };
+
+template <typename T>
+inline bool is_zero(T value, T tolerance = std::numeric_limits<T>::epsilon())
+{
+  return std::abs(value) <= tolerance;
+}
 
 /***************************************************/
 /*!
@@ -316,7 +316,7 @@ public:
       }
       try
       {
-        antiwindup_strat_.validate(i_gain_);
+        antiwindup_strat_.validate();
       }
       catch (const std::exception & e)
       {

--- a/control_toolbox/src/pid_ros.cpp
+++ b/control_toolbox/src/pid_ros.cpp
@@ -207,7 +207,7 @@ bool PidROS::initialize_from_ros_parameters()
 
   try
   {
-    antiwindup_strat.validate(i);
+    antiwindup_strat.validate();
   }
   catch (const std::exception & e)
   {


### PR DESCRIPTION
Fix a couple of issues with tracking time constant used for back propagation anti-windup strategy
- fix divide-by-zero bug in calculation of tracking time constant which cause time constant to be infinite and thus fail validation check and prevent updating of gains


Note: maybe there is a better way of fixing this but this resolved my issue where I was unable to change gains using rqt when i-gain was set to zero and tracking time constant was at its default of zero.