### PR TITLE
 [PidROS] Change args to const reference

### DIFF
--- a/control_toolbox/include/control_toolbox/pid_ros.hpp
+++ b/control_toolbox/include/control_toolbox/pid_ros.hpp
@@ -95,8 +95,8 @@ public:
    */
   template <class NodeT>
   explicit PidROS(
-    std::shared_ptr<NodeT> node_ptr, std::string param_prefix, std::string topic_prefix,
-    bool activate_state_publisher)
+    std::shared_ptr<NodeT> node_ptr, const std::string & param_prefix,
+    const std::string & topic_prefix, bool activate_state_publisher)
   : PidROS(
       node_ptr->get_node_base_interface(), node_ptr->get_node_logging_interface(),
       node_ptr->get_node_parameters_interface(), node_ptr->get_node_topics_interface(),


### PR DESCRIPTION
Change the constructor args to const ref instead of a copy