### PR TITLE
Fix testcase for invalid value at node initialization

### DIFF
--- a/control_toolbox/test/control_filters/test_low_pass_filter.cpp
+++ b/control_toolbox/test/control_filters/test_low_pass_filter.cpp
@@ -51,7 +51,7 @@ TEST_F(FilterTest, TestLowPassWrenchFilterMissingParameter)
     node_->get_node_parameters_interface()));
 }
 
-TEST_F(FilterTest, TestLowPassWrenchFilterInvalidThenFixedParameter)
+TEST_F(FilterTest, TestLowPassWrenchFilterInvalidParameter)
 {
   std::shared_ptr<filters::FilterBase<geometry_msgs::msg::WrenchStamped>> filter_ =
     std::make_shared<control_filters::LowPassFilter<geometry_msgs::msg::WrenchStamped>>();
@@ -60,13 +60,10 @@ TEST_F(FilterTest, TestLowPassWrenchFilterInvalidThenFixedParameter)
   ASSERT_FALSE(filter_->configure(
     "", "TestLowPassFilter", node_->get_node_logging_interface(),
     node_->get_node_parameters_interface()));
-
-  // fix the param
-  node_->set_parameter(rclcpp::Parameter("sampling_frequency", 1000.0));
-  // should allow configuration and pass second call to unconfigured filter
-  ASSERT_TRUE(filter_->configure(
-    "", "TestLowPassFilter", node_->get_node_logging_interface(),
-    node_->get_node_parameters_interface()));
+  // remains now undeclared, so should throw if we try to set it
+  ASSERT_THROW(
+    node_->set_parameter(rclcpp::Parameter("sampling_frequency", 1000.0)),
+    rclcpp::exceptions::ParameterNotDeclaredException);
 }
 
 TEST_F(FilterTest, TestLowPassFilterThrowsUnconfigured)

--- a/control_toolbox/test/control_filters/test_low_pass_filter_parameters.yaml
+++ b/control_toolbox/test/control_filters/test_low_pass_filter_parameters.yaml
@@ -9,7 +9,7 @@ TestLowPassWrenchFilterMissingParameter:
     damping_frequency: 20.5
     damping_intensity: 1.25
 
-TestLowPassWrenchFilterInvalidThenFixedParameter:
+TestLowPassWrenchFilterInvalidParameter:
   ros__parameters:
     sampling_frequency: 0.0
     damping_frequency: 20.5


### PR DESCRIPTION
Since https://github.com/PickNikRobotics/generate_parameter_library/pull/339 the behavior of generate_parameter_library changed.
The parameter in the testcase can't even be declared as zero now (earlier it was declared with 0 but the validator failed later).

```
2026-05-18T07:35:36.9553861Z     [ RUN      ] FilterTest.TestLowPassWrenchFilterInvalidThenFixedParameter
2026-05-18T07:35:36.9555026Z     [ERROR] [1779089735.022610158] [TestLowPassWrenchFilterInvalidThenFixedParameter.TestLowPassFilter]: LowPass filter cannot be configured: parameter 'sampling_frequency' could not be set: Parameter {sampling_frequency} doesn't comply with floating point range. (type : N6rclcpp10exceptions30InvalidParameterValueExceptionE)
2026-05-18T07:35:36.9556068Z     unknown file: Failure
2026-05-18T07:35:36.9556522Z     C++ exception with description "parameter 'sampling_frequency' cannot be set because it was not declared" thrown in the test body.
2026-05-18T07:35:36.9556934Z     
2026-05-18T07:35:36.9557232Z     [  FAILED  ] FilterTest.TestLowPassWrenchFilterInvalidThenFixedParameter (7 ms)
```

### Is this user-facing behavior change?
no

### Did you use Generative AI?
no