### PR TITLE
Define _USE_MATH_DEFINES for each target that links control_toolbox on WIN32

### DIFF
--- a/control_toolbox/CMakeLists.txt
+++ b/control_toolbox/CMakeLists.txt
@@ -52,7 +52,9 @@ target_link_libraries(control_toolbox PUBLIC
   realtime_tools::realtime_tools
 )
 target_compile_definitions(control_toolbox PRIVATE "CONTROL_TOOLBOX_BUILDING_LIBRARY")
-
+if(WIN32)
+  target_compile_definitions(control_toolbox PUBLIC "_USE_MATH_DEFINES")
+endif()
 
 ########################
 # Build control filters


### PR DESCRIPTION

Fixes downstream compilation problems on Windows.

`M_PI` is used in public headers in https://github.com/ros-controls/control_toolbox/blob/e274281b41eb1c3f4817b2226c4ddbc6863b5d66/control_toolbox/include/control_toolbox/low_pass_filter.hpp#L118, so we need to ensure that `_USE_MATH_DEFINES` is always defined also for downstream compilation units that include `control_toolbox/low_pass_filter.hpp`. This can be done by setting as `PUBLIC` target_compile_definitions `_USE_MATH_DEFINES`.

This fixes errors like:

~~~
 │ │ %PREFIX%\Library\include\control_toolbox\control_toolbox\low_pass_filter.hpp(117,42): error C2065: 'M_PI': undeclared identifier [%SRC_DIR%\build\gz_custom_hardware_plugins.vcxproj]
 │ │   (compiling source file '../ros-jazzy-gz-ros2-control-demos/src/work/src/gz_custom_system.cpp')
 │ │       %PREFIX%\Library\include\control_toolbox\control_toolbox\low_pass_filter.hpp(117,42):
 │ │       the template instantiation context (the oldest one first) is
 │ │           %SRC_DIR%\ros-jazzy-gz-ros2-control-demos\src\work\src\gz_custom_system.cpp(266,34):
 │ │           see reference to class template instantiation 'control_toolbox::LowPassFilter<double>' being compiled
 │ │           %PREFIX%\Library\include\control_toolbox\control_toolbox\low_pass_filter.hpp(114,8):
 │ │           while compiling class template member function 'void control_toolbox::LowPassFilter<double>::set_params(double,double,double)'
 │ │               %PREFIX%\Library\include\control_toolbox\control_toolbox\low_pass_filter.hpp(85,15):
 │ │               see the first reference to 'control_toolbox::LowPassFilter<double>::set_params' in 'control_toolbox::LowPassFilter<double>::LowPassFilter'
 │ │               C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,5):
 │ │               see the first reference to 'control_toolbox::LowPassFilter<double>::LowPassFilter' in 'std::make_unique'
 │ │   
 │ │ %SRC_DIR%\build>if errorlevel 1 exit 1
 ~~~

see https://github.com/RoboStack/ros-jazzy/pull/212#issuecomment-4560518729 .



### Is this user-facing behavior change?

No.

### Did you use Generative AI?

Surprisingly no.

### Additional Information

None.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
