### PR TITLE
Fix race condition with tf buffer

### DIFF
--- a/control_toolbox/include/control_filters/gravity_compensation.hpp
+++ b/control_toolbox/include/control_filters/gravity_compensation.hpp
@@ -93,14 +93,12 @@ GravityCompensation<T>::~GravityCompensation()
 template <typename T>
 bool GravityCompensation<T>::configure()
 {
-  clock_ = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  p_tf_Buffer_.reset(new tf2_ros::Buffer(clock_));
-  p_tf_Listener_.reset(new tf2_ros::TransformListener(*p_tf_Buffer_.get(), true));
-
   logger_.reset(
     new rclcpp::Logger(this->logging_interface_->get_logger().get_child(this->filter_name_)));
 
-  // Initialize the parameter_listener once
+  // Parse and validate parameters before creating the TF listener. Constructing the listener spawns
+  // a background executor thread; if a required parameter is missing the ParamListener throws, and
+  // tearing that thread down mid-unwind can deadlock (flaky configure hang).
   if (!parameter_handler_)
   {
     try
@@ -117,6 +115,10 @@ bool GravityCompensation<T>::configure()
   }
   parameters_ = parameter_handler_->get_params();
   compute_internal_params();
+
+  clock_ = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  p_tf_Buffer_.reset(new tf2_ros::Buffer(clock_));
+  p_tf_Listener_.reset(new tf2_ros::TransformListener(*p_tf_Buffer_.get(), true));
 
   return true;
 }


### PR DESCRIPTION
<!--
Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:

1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
2. Give your PR a descriptive title. Add a short summary, if required.
3. Make sure the pipeline is green.
4. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
5. If a PR is merged all commits will get squashed, a linear commit history is not required.
6. Once a PR got reviewed, please don't do force pushes as this will break github UI and subsequent reviews will take more time.
-->

## Description
Parse and validate parameters before creating the TF listener. Constructing the listener spawns
a background executor thread; if a required parameter is missing the ParamListener throws, and
tearing that thread down mid-unwind can deadlock (flaky configure hang).

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #385

### Is this user-facing behavior change?
no

### Did you use Generative AI?

GPT Codex 5.3