### PR TITLE
Add configure() overload to set the initial LPF state

### DIFF
--- a/control_toolbox/CMakeLists.txt
+++ b/control_toolbox/CMakeLists.txt
@@ -174,6 +174,9 @@ if(BUILD_TESTING)
   ament_add_gmock(rate_limiter_tests test/rate_limiter.cpp)
   target_link_libraries(rate_limiter_tests control_toolbox)
 
+  ament_add_gmock(low_pass_filter_tests test/low_pass_filter_tests.cpp)
+  target_link_libraries(low_pass_filter_tests control_toolbox Eigen3::Eigen ${geometry_msgs_TARGETS})
+
   ament_add_gmock(pid_ros_parameters_tests test/pid_ros_parameters_tests.cpp)
   target_link_libraries(pid_ros_parameters_tests control_toolbox)
 

--- a/control_toolbox/include/control_toolbox/low_pass_filter.hpp
+++ b/control_toolbox/include/control_toolbox/low_pass_filter.hpp
@@ -93,8 +93,27 @@ public:
 
   /*!
    * \brief Configure the LowPassFilter (access and process params).
+   *
+   * The internal state is left uninitialized, so that the filter is initialized with
+   * the input of the first update() call.
+   *
+   * \returns true
    */
   bool configure();
+
+  /*!
+   * \brief Configure the LowPassFilter and initialize its internal state.
+   *
+   * In contrast to configure(), the filter starts from \p initial_state instead of from
+   * the input of the first update() call. The first update() therefore returns
+   * \p initial_state, and the filter converges towards the input from there.
+   *
+   * \param initial_state Initial state of the filter
+   *
+   * \returns false if \p initial_state is not finite, leaving the filter unchanged,
+   * true otherwise
+   */
+  bool configure(const T & initial_state);
 
   /*!
    * \brief Applies one iteration of the IIR filter.
@@ -121,6 +140,13 @@ public:
   };
 
 private:
+  /*!
+   * \brief Set the internal state of the filter to a steady state at the given value.
+   *
+   * \param state value all the internal state variables are set to
+   */
+  void initialize_state(const T & state);
+
   // Filter parameters
   double a1_; /** feedbackward coefficient. */
   double b1_; /** feedforward coefficient. */
@@ -145,12 +171,32 @@ LowPassFilter<T>::~LowPassFilter()
 }
 
 template <typename T>
+void LowPassFilter<T>::initialize_state(const T & state)
+{
+  Traits::assign(filtered_value_, state);
+  Traits::assign(filtered_old_value_, state);
+  Traits::assign(old_value_, state);
+}
+
+template <typename T>
 bool LowPassFilter<T>::configure()
 {
   Traits::initialize(filtered_value_);
   Traits::initialize(filtered_old_value_);
   Traits::initialize(old_value_);
 
+  return configured_ = true;
+}
+
+template <typename T>
+bool LowPassFilter<T>::configure(const T & initial_state)
+{
+  if (!Traits::is_finite(initial_state))
+  {
+    return false;
+  }
+
+  initialize_state(initial_state);
   return configured_ = true;
 }
 
@@ -170,9 +216,7 @@ bool LowPassFilter<T>::update(const T & data_in, T & data_out)
       return false;
     }
 
-    Traits::assign(filtered_value_, data_in);
-    Traits::assign(filtered_old_value_, data_in);
-    Traits::assign(old_value_, data_in);
+    initialize_state(data_in);
   }
   else
   {

--- a/control_toolbox/include/control_toolbox/low_pass_filter.hpp
+++ b/control_toolbox/include/control_toolbox/low_pass_filter.hpp
@@ -105,8 +105,9 @@ public:
    * \brief Configure the LowPassFilter and initialize its internal state.
    *
    * In contrast to configure(), the filter starts from \p initial_state instead of from
-   * the input of the first update() call. The first update() therefore returns
-   * \p initial_state, and the filter converges towards the input from there.
+   * the input of the first update() call. The first update() therefore returns the
+   * stored signal values from \p initial_state, and the filter converges towards the input
+   * from there (metadata, if any, is still taken from the update() input).
    *
    * \param initial_state Initial state of the filter
    *

--- a/control_toolbox/test/low_pass_filter_tests.cpp
+++ b/control_toolbox/test/low_pass_filter_tests.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2026, ros2_control development team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+
+#include <limits>
+#include <vector>
+
+#include "control_toolbox/low_pass_filter.hpp"
+
+#include "geometry_msgs/msg/wrench_stamped.hpp"
+
+TEST(LowPassFilterTest, FirstUpdateReturnsInitialState)
+{
+  control_toolbox::LowPassFilter<double> filter(1000.0, 20.5, 1.25);
+
+  ASSERT_TRUE(filter.configure(1.5));
+
+  double out = 0.0;
+  ASSERT_TRUE(filter.update(10.0, out));
+
+  EXPECT_NEAR(out, 1.5, 1e-12);
+}
+
+TEST(LowPassFilterTest, RejectsNonFiniteInitialState)
+{
+  control_toolbox::LowPassFilter<double> filter(1000.0, 20.5, 1.25);
+
+  EXPECT_FALSE(filter.configure(std::numeric_limits<double>::quiet_NaN()));
+  EXPECT_FALSE(filter.is_configured());
+
+  EXPECT_FALSE(filter.configure(std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(filter.is_configured());
+}
+
+TEST(LowPassFilterTest, WithoutInitialStateFirstUpdateReturnsInput)
+{
+  control_toolbox::LowPassFilter<double> filter(1000.0, 20.5, 1.25);
+
+  ASSERT_TRUE(filter.configure());
+
+  double out = 0.0;
+  ASSERT_TRUE(filter.update(10.0, out));
+
+  EXPECT_NEAR(out, 10.0, 1e-12);
+}
+
+TEST(LowPassFilterTest, VectorFirstUpdateReturnsInitialState)
+{
+  control_toolbox::LowPassFilter<std::vector<double>> filter(1000.0, 20.5, 1.25);
+
+  const std::vector<double> initial_state = {1.0, -2.0, 3.0};
+  ASSERT_TRUE(filter.configure(initial_state));
+
+  std::vector<double> out(initial_state.size(), 0.0);
+  ASSERT_TRUE(filter.update({10.0, 10.0, 10.0}, out));
+
+  ASSERT_EQ(out.size(), initial_state.size());
+  for (size_t i = 0; i < out.size(); ++i)
+  {
+    EXPECT_NEAR(out[i], initial_state[i], 1e-12);
+  }
+}
+
+TEST(LowPassFilterTest, WrenchFirstUpdateReturnsInitialState)
+{
+  control_toolbox::LowPassFilter<geometry_msgs::msg::WrenchStamped> filter(1000.0, 20.5, 1.25);
+
+  geometry_msgs::msg::WrenchStamped initial_state;
+  initial_state.wrench.force.x = 1.0;
+  initial_state.wrench.torque.z = 6.0;
+  ASSERT_TRUE(filter.configure(initial_state));
+
+  geometry_msgs::msg::WrenchStamped in;
+  in.header.frame_id = "world";
+  in.wrench.force.x = 100.0;
+  in.wrench.torque.z = 100.0;
+
+  geometry_msgs::msg::WrenchStamped out;
+  ASSERT_TRUE(filter.update(in, out));
+
+  EXPECT_NEAR(out.wrench.force.x, 1.0, 1e-12);
+  EXPECT_NEAR(out.wrench.torque.z, 6.0, 1e-12);
+}


### PR DESCRIPTION
## Description

`LowPassFilter` always initializes its state from the first `update()` input, so there's
no way to start it from a known value.

This PR adds a `configure(const T & initial_state)` overload that seeds the state: the first
`update()` returns `initial_state` and the filter converges towards the input from there.

Fixes #643

### Is this user-facing behavior change?

Yes, additive only. Existing `configure()` calls behave exactly as before. 

### Did you use Generative AI?

Implementation written by hand. Claude Code (Opus 5) reviewed it and helped write the unit tests.

### Additional Information

The new tests cover all three supported types (`double`, `std::vector<double>`,
`WrenchStamped`). These are the first direct unit tests of `control_toolbox::LowPassFilter`;
the existing ones only reach it through the plugin.

## TODOs

To send us a pull request, please:

- [x] Fork the repository.
- [x] Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- [x] Ensure local tests pass. (`colcon test` and `pre-commit run` (requires you to install pre-commit by `pip3 install pre-commit`)
- [x] Commit to your fork using clear commit messages.
- [x] Send a pull request, answering any default questions in the pull request interface.
- [x] Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
